### PR TITLE
Expose ws_close to FreeAtHome object, make callbacks optional

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ packages = ["src/abbfreeathome"]
 
 [project]
 name = "local-abbfreeathome"
-version = "1.1.0"
+version = "1.2.0"
 authors = [
   { name="Adam Kingsley", email="adam@kingsley.io" },
 ]

--- a/src/abbfreeathome/api.py
+++ b/src/abbfreeathome/api.py
@@ -244,14 +244,14 @@ class FreeAtHomeApi:
         await self._ws_response.close()
 
     async def ws_listen(
-        self, callback: Callable[[list], None], retry_interval: int = 5
+        self, callback: Callable[[list], None] | None = None, retry_interval: int = 5
     ):  # pragma: no cover
         """Listen for events on the websocket."""
         while True:
             await self.ws_receive(callback, retry_interval)
 
     async def ws_receive(
-        self, callback: Callable[[list], None], retry_interval: int = 5
+        self, callback: Callable[[list], None] | None = None, retry_interval: int = 5
     ):
         """Receive an event on the websocket."""
         if not self._ws_response or not self.ws_connected:
@@ -273,9 +273,9 @@ class FreeAtHomeApi:
         data = await self._ws_response.receive()
         if data.type == aiohttp.WSMsgType.TEXT:
             _ws_data = data.json().get(self._sysap_uuid)
-            if inspect.iscoroutinefunction(callback):
+            if callback and inspect.iscoroutinefunction(callback):
                 await callback(_ws_data)
-            else:
+            elif callback:
                 callback(_ws_data)
         elif data.type == aiohttp.WSMsgType.ERROR:
             _LOGGER.error("Websocket Response Error. Data: %s", data)

--- a/src/abbfreeathome/freeathome.py
+++ b/src/abbfreeathome/freeathome.py
@@ -113,6 +113,10 @@ class FreeAtHome:
                 )
             )
 
+    async def ws_close(self):
+        """Close the websocker connection."""
+        await self._api.ws_close()
+
     async def ws_listen(self):
         """Listen on the websocket for updates to devices."""
         await self._api.ws_listen(callback=self.update_device)

--- a/tests/test_freeathome.py
+++ b/tests/test_freeathome.py
@@ -216,6 +216,14 @@ async def test_load_devices(freeathome):
 
 
 @pytest.mark.asyncio
+async def test_ws_close(freeathome, api_mock):
+    "Test the ws_close function."
+    api_mock.ws_close = AsyncMock()
+    await freeathome.ws_close()
+    api_mock.ws_close.assert_called_once_with()
+
+
+@pytest.mark.asyncio
 async def test_ws_listen(freeathome, api_mock):
     "Test the ws_listen function."
     api_mock.ws_listen = AsyncMock()


### PR DESCRIPTION
Exposes the ws_close to the FreeAtHome class to allow the class to close the websocket if needed.

Makes the callback optional on the websocket listen, mostly for testing purposes.