### PR TITLE
Add fix for no Floor/Room assigned to Device.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ packages = ["src/abbfreeathome"]
 
 [project]
 name = "local-abbfreeathome"
-version = "1.2.0"
+version = "1.2.1"
 authors = [
   { name="Adam Kingsley", email="adam@kingsley.io" },
 ]

--- a/src/abbfreeathome/devices/base.py
+++ b/src/abbfreeathome/devices/base.py
@@ -58,12 +58,12 @@ class Base:
         return self._channel_name
 
     @property
-    def floor_name(self) -> str:
+    def floor_name(self) -> str | None:
         """Get the floor name of the device."""
         return self._floor_name
 
     @property
-    def room_name(self) -> str:
+    def room_name(self) -> str | None:
         """Get the room name of the device."""
         return self._room_name
 

--- a/src/abbfreeathome/freeathome.py
+++ b/src/abbfreeathome/freeathome.py
@@ -65,20 +65,25 @@ class FreeAtHome:
 
         return _devices
 
-    async def get_floor_name(self, floor_serial_id: str) -> str:
+    async def get_floor_name(self, floor_serial_id: str) -> str | None:
         """Get the floor name from the configuration."""
-        _default_room = {"name": "unknown", "rooms": {}}
-        return (await self.floors).get(floor_serial_id, _default_room).get("name")
+        _default_floor = {"name": None}
 
-    async def get_room_name(self, floor_serial_id: str, room_serial_id: str) -> str:
+        return (await self.floors).get(floor_serial_id, _default_floor).get("name")
+
+    async def get_room_name(
+        self, floor_serial_id: str, room_serial_id: str
+    ) -> str | None:
         """Get the room name from the configuration."""
-        _default_room = {"name": "unknown", "rooms": {}}
+        _default_floor = {"name": None, "rooms": {}}
+        _default_room = {"name": None}
+
         return (
             (await self.floors)
-            .get(floor_serial_id, _default_room)
+            .get(floor_serial_id, _default_floor)
             .get("rooms")
-            .get(room_serial_id)
-            .get("name", "unknown")
+            .get(room_serial_id, _default_room)
+            .get("name")
         )
 
     def get_device_by_class(self, device_class: Base) -> list[Base]:

--- a/tests/test_freeathome.py
+++ b/tests/test_freeathome.py
@@ -183,12 +183,30 @@ async def test_get_floor_name(freeathome):
     floor_name = await freeathome.get_floor_name("01")
     assert floor_name == "Ground Floor"
 
+    floor_name = await freeathome.get_floor_name(floor_serial_id=None)
+    assert floor_name is None
+
 
 @pytest.mark.asyncio
 async def test_get_room_name(freeathome):
     """Test the get_room_name function."""
     room_name = await freeathome.get_room_name("01", "01")
     assert room_name == "Living Room"
+
+    room_name = await freeathome.get_room_name(
+        floor_serial_id="01", room_serial_id=None
+    )
+    assert room_name is None
+
+    room_name = await freeathome.get_room_name(
+        floor_serial_id=None, room_serial_id=None
+    )
+    assert room_name is None
+
+    room_name = await freeathome.get_room_name(
+        floor_serial_id=None, room_serial_id="01"
+    )
+    assert room_name is None
 
 
 def test_get_device_by_class(freeathome):


### PR DESCRIPTION
This fixes #13, when no floor or room is assigned to a device, the code should not fail. Instead it should return a `None` value.

Also addressed this scenario in UnitTests.