### PR TITLE
Add hardware version to the settings class

### DIFF
--- a/src/abbfreeathome/api.py
+++ b/src/abbfreeathome/api.py
@@ -69,6 +69,11 @@ class FreeAtHomeSettings:
         return self._settings.get("flags").get(name)
 
     @property
+    def hardware_version(self):
+        """Get the hardware vesion running on SysAP."""
+        return self.get_flag("hardwareVersion")
+
+    @property
     def version(self):
         """Get the vesion running on SysAP."""
         return self.get_flag("version")

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -42,6 +42,7 @@ async def test_load_success(settings):
                     "version": "1.0",
                     "serialNumber": "12345",
                     "name": "SysAP",
+                    "hardwareVersion": "54321",
                 },
             },
         )
@@ -49,7 +50,12 @@ async def test_load_success(settings):
         await settings.load()
         assert settings._settings == {
             "users": [{"name": "test_user"}],
-            "flags": {"version": "1.0", "serialNumber": "12345", "name": "SysAP"},
+            "flags": {
+                "version": "1.0",
+                "serialNumber": "12345",
+                "name": "SysAP",
+                "hardwareVersion": "54321",
+            },
         }
 
 
@@ -79,6 +85,12 @@ def test_get_flag(settings):
     """Test getting a single flag."""
     settings._settings = {"flags": {"version": "1.0"}}
     assert settings.get_flag("version") == "1.0"
+
+
+def test_hardware_version_property(settings):
+    """Test getting verison."""
+    settings._settings = {"flags": {"hardwareVersion": "54321"}}
+    assert settings.hardware_version == "54321"
 
 
 def test_version_property(settings):


### PR DESCRIPTION
This adds the hardware version as a property to the FreeAtHomeSettings class. To be used by Home Assistant when creating the Hub entitiy.