### PR TITLE
Allow for filtering of devices by interface

### DIFF
--- a/src/abbfreeathome/bin/interface.py
+++ b/src/abbfreeathome/bin/interface.py
@@ -1,0 +1,18 @@
+"""
+Defines the avaliable interfaces in the Free@Home System.
+
+This is not a comprehensive list. To add new interfaces please open a GitHub issue:
+https://github.com/kingsleyadam/local-abbfreeathome/issues
+"""
+
+import enum
+
+
+class Interface(enum.Enum):
+    """An Enum class for Free@Home interfaces."""
+
+    UNDEFINED = None
+    WIRED_BUS = "TP"
+    HUE = "hue"
+    SONOS = "sonos"
+    VIRTUAL_DEVICE = "vdev:installer@busch-jaeger.de"

--- a/tests/test_freeathome.py
+++ b/tests/test_freeathome.py
@@ -6,6 +6,7 @@ import pytest
 
 from abbfreeathome.api import FreeAtHomeApi
 from abbfreeathome.bin.function_id import FunctionID
+from abbfreeathome.bin.interface import Interface
 from abbfreeathome.devices.switch_actuator import SwitchActuator
 from abbfreeathome.freeathome import FreeAtHome
 
@@ -135,6 +136,29 @@ def api_mock():
                 },
                 "parameters": {"par00ed": "1"},
             },
+            "BEED509C0001": {
+                "floor": "01",
+                "room": "01",
+                "interface": "hue",
+                "deviceId": "10C0",
+                "displayName": "LED Strip",
+                "unresponsive": False,
+                "unresponsiveCounter": 0,
+                "defect": False,
+                "channels": {
+                    "ch0000": {
+                        "floor": "02",
+                        "room": "06",
+                        "displayName": "TV LED Strip Top",
+                        "selectedIcon": "6a",
+                        "functionID": "2e",
+                        "inputs": {},
+                        "outputs": {},
+                        "parameters": {},
+                    }
+                },
+                "parameters": {},
+            },
         },
     }
     return api
@@ -143,7 +167,7 @@ def api_mock():
 @pytest.fixture
 def freeathome(api_mock):
     """Create the FreeAtHome fixture."""
-    return FreeAtHome(api=api_mock)
+    return FreeAtHome(api=api_mock, interfaces=[Interface.WIRED_BUS])
 
 
 @pytest.mark.asyncio
@@ -170,9 +194,7 @@ async def test_get_config(freeathome, api_mock):
 @pytest.mark.asyncio
 async def test_get_devices_by_function(freeathome):
     """Test the get_devices_by_fuction function."""
-    devices = await freeathome.get_devices_by_function(
-        FunctionID.FID_SWITCH_ACTUATOR.value
-    )
+    devices = await freeathome.get_devices_by_function(FunctionID.FID_SWITCH_ACTUATOR)
     assert len(devices) == 2
     assert devices[0]["device_name"] == "Study Area Rocker"
     assert devices[0]["channel_name"] == "Study Area Light"


### PR DESCRIPTION
This addresses #17 by allowing for filtering of devices by interface.

I've added a new `enum` for interfaces to make it clear what can be filtered on, and to be able to use an `UNDEFINED` interface. An `UNDEFINED` lines up with a device that doesn't provide an interface at all. Some scenes, virtual devices, and other devices do not provide an interface.

This will be passed to the FreeAtHome class as a new variable `interfaces` and any calls to the class will filter out the devices by this list. If the variable is not provided then there will be no device filtering.

I've adjusted the unit test to include a `hue` device to test against this filtering scenario.

Some other quality of life improvements to this PR:

- When calling `get_devices_by_function` we'll pass in the the Enum object vs `value`.
- When calling `get_device_by_class` we'll loop through the values since the key isn't being used here.

