### PR TITLE
Check for function value before testing for function id

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ packages = ["src/abbfreeathome"]
 
 [project]
 name = "local-abbfreeathome"
-version = "1.3.1"
+version = "1.3.2"
 authors = [
   { name="Adam Kingsley", email="adam@kingsley.io" },
 ]

--- a/src/abbfreeathome/freeathome.py
+++ b/src/abbfreeathome/freeathome.py
@@ -37,7 +37,10 @@ class FreeAtHome:
                 continue
 
             for _channel_key, _channel in _device.get("channels", {}).items():
-                if int(_channel.get("functionID"), 16) == function_id.value:
+                if (
+                    _channel.get("functionID")
+                    and int(_channel.get("functionID"), 16) == function_id.value
+                ):
                     _channel_name = _channel.get("displayName")
                     if _channel_name == "Ⓐ" or _channel_name is None:
                         _channel_name = _device.get("displayName")


### PR DESCRIPTION
This addresses #27 , this will check for a function before testing for the id. Merely testing for `_channel.get("functionID")` will check for any `None` types or empty strings.

Bump version.