### PR TITLE
Refactor enums, freeathome, pairing

### DIFF
--- a/src/abbfreeathome/bin/function.py
+++ b/src/abbfreeathome/bin/function.py
@@ -8,7 +8,7 @@ Converted With: https://github.com/nitzano/enum-converter?tab=readme-ov-file
 import enum
 
 
-class FunctionID(enum.Enum):
+class Function(enum.Enum):
     """An Enum class for all Free@Home functions."""
 
     FID_SWITCH_SENSOR = 0

--- a/src/abbfreeathome/bin/pairing.py
+++ b/src/abbfreeathome/bin/pairing.py
@@ -8,9 +8,10 @@ Converted With: https://github.com/nitzano/enum-converter?tab=readme-ov-file
 import enum
 
 
-class PairingId(enum.Enum):
+class Pairing(enum.Enum):
     """An Enum class for all Free@Home pairings."""
 
+    AL_INVALID = 0
     AL_SWITCH_ON_OFF = 1
     AL_TIMED_START_STOP = 2
     AL_FORCED = 3
@@ -21,6 +22,7 @@ class PairingId(enum.Enum):
     AL_ABSOLUTE_SET_VALUE_CONTROL = 17
     AL_NIGHT = 18
     AL_RESET_ERROR = 19
+    AL_NIGHT_ACTUATOR_FOR_SYSAP = 20
     AL_RGB = 21
     AL_COLOR_TEMPERATURE = 22
     AL_HSV = 23
@@ -330,4 +332,3 @@ class PairingId(enum.Enum):
     AL_MEASURED_TEMPERATURE_3 = 65283
     AL_MEASURED_TEMPERATURE_4 = 65284
     AL_IGNORE = 65534
-    AL_INVALID = 65535

--- a/src/abbfreeathome/bin/parameter.py
+++ b/src/abbfreeathome/bin/parameter.py
@@ -8,7 +8,7 @@ Converted With: https://github.com/nitzano/enum-converter?tab=readme-ov-file
 import enum  # pragma: no cover
 
 
-class ParameterId(enum.Enum):  # pragma: no cover
+class Parameter(enum.Enum):  # pragma: no cover
     """An Enum class for all Free@Home parameters."""
 
     PID_LED_DAY_BRIGHTNESS = 1

--- a/src/abbfreeathome/devices/base.py
+++ b/src/abbfreeathome/devices/base.py
@@ -4,7 +4,8 @@ from collections.abc import Callable
 from typing import Any
 
 from ..api import FreeAtHomeApi
-from ..exceptions import InvalidDeviceChannelPairingId
+from ..bin.pairing import Pairing
+from ..exceptions import InvalidDeviceChannelPairing
 
 
 class Base:
@@ -67,21 +68,25 @@ class Base:
         """Get the room name of the device."""
         return self._room_name
 
-    def get_input_by_pairing_id(self, pairing_id: int) -> tuple[str, Any]:
+    def get_input_by_pairing(self, pairing: Pairing) -> tuple[str, Any]:
         """Get the channel input by pairing id."""
         for _input_id, _input in self._inputs.items():
-            if _input.get("pairingID") == pairing_id:
+            if _input.get("pairingID") == pairing.value:
                 return _input_id, _input.get("value")
 
-        raise InvalidDeviceChannelPairingId(self.device_id, self.channel_id, pairing_id)
+        raise InvalidDeviceChannelPairing(
+            self.device_id, self.channel_id, pairing.value
+        )
 
-    def get_output_by_pairing_id(self, pairing_id: int) -> tuple[str, Any]:
+    def get_output_by_pairing(self, pairing: Pairing) -> tuple[str, Any]:
         """Get the channel output by pairing id."""
         for _output_id, _output in self._outputs.items():
-            if _output.get("pairingID") == pairing_id:
+            if _output.get("pairingID") == pairing.value:
                 return _output_id, _output.get("value")
 
-        raise InvalidDeviceChannelPairingId(self.device_id, self.channel_id, pairing_id)
+        raise InvalidDeviceChannelPairing(
+            self.device_id, self.channel_id, pairing.value
+        )
 
     def update_device():
         """Update a devices state."""

--- a/src/abbfreeathome/devices/switch_actuator.py
+++ b/src/abbfreeathome/devices/switch_actuator.py
@@ -4,7 +4,7 @@ import logging
 from typing import Any
 
 from ..api import FreeAtHomeApi
-from ..bin.pairing_id import PairingId
+from ..bin.pairing import Pairing
 from .base import Base
 
 _LOGGER = logging.getLogger(__name__)
@@ -62,8 +62,8 @@ class SwitchActuator(Base):
 
     async def refresh_state(self):
         """Refresh the state of the switch from the api."""
-        _switch_output_id, _switch_output_value = self.get_output_by_pairing_id(
-            pairing_id=PairingId.AL_INFO_ON_OFF.value
+        _switch_output_id, _switch_output_value = self.get_output_by_pairing(
+            pairing=Pairing.AL_INFO_ON_OFF
         )
 
         _datapoint = (
@@ -81,14 +81,14 @@ class SwitchActuator(Base):
 
     def _refresh_state_from_outputs(self):
         """Refresh the state of the switch from the _outputs."""
-        _switch_output_id, _switch_output_value = self.get_output_by_pairing_id(
-            pairing_id=PairingId.AL_INFO_ON_OFF.value
+        _switch_output_id, _switch_output_value = self.get_output_by_pairing(
+            pairing=Pairing.AL_INFO_ON_OFF
         )
         self._state = _switch_output_value == "1"
 
     async def _set_switching_datapoint(self, value: str):
-        _switch_input_id, _switch_input_value = self.get_input_by_pairing_id(
-            pairing_id=PairingId.AL_SWITCH_ON_OFF.value
+        _switch_input_id, _switch_input_value = self.get_input_by_pairing(
+            pairing=Pairing.AL_SWITCH_ON_OFF
         )
         return await self._api.set_datapoint(
             device_id=self.device_id,

--- a/src/abbfreeathome/exceptions.py
+++ b/src/abbfreeathome/exceptions.py
@@ -52,14 +52,14 @@ class InvalidApiResponseException(FreeAtHomeException):
         super().__init__(self.message)
 
 
-class InvalidDeviceChannelPairingId(FreeAtHomeException):
+class InvalidDeviceChannelPairing(FreeAtHomeException):
     """Raise an exception for an invalid pairing id."""
 
-    def __init__(self, device_id: str, channel_id: str, pairing_id: int) -> None:
-        """Initialze the InvalidDeviceChannelPairingId class."""
+    def __init__(self, device_id: str, channel_id: str, pairing_value: int) -> None:
+        """Initialze the InvalidDeviceChannelPairing class."""
         self.message = (
             f"Could not find paring id for "
-            f"device: {device_id}; channel: {channel_id}; pairing id: {pairing_id}"
+            f"device: {device_id}; channel: {channel_id}; pairing id: {pairing_value}"
         )
         super().__init__(self.message)
 

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -5,8 +5,9 @@ from unittest.mock import MagicMock
 import pytest
 
 from abbfreeathome.api import FreeAtHomeApi
+from abbfreeathome.bin.pairing import Pairing
 from abbfreeathome.devices.base import Base
-from abbfreeathome.exceptions import InvalidDeviceChannelPairingId
+from abbfreeathome.exceptions import InvalidDeviceChannelPairing
 
 
 @pytest.fixture
@@ -55,24 +56,24 @@ def test_initialization(base_instance):
     assert base_instance.room_name == "Study"
 
 
-def test_get_input_by_pairing_id(base_instance):
-    """Test the get_input_pairing_id function."""
-    input_id, value = base_instance.get_input_by_pairing_id(1)
+def test_get_input_by_pairing(base_instance):
+    """Test the get_input_pairing function."""
+    input_id, value = base_instance.get_input_by_pairing(Pairing.AL_SWITCH_ON_OFF)
     assert input_id == "idp0000"
     assert value == "0"
 
-    with pytest.raises(InvalidDeviceChannelPairingId):
-        base_instance.get_input_by_pairing_id(99)
+    with pytest.raises(InvalidDeviceChannelPairing):
+        base_instance.get_input_by_pairing(Pairing.AL_HSV)
 
 
-def test_get_output_by_pairing_id(base_instance):
-    """Test the get_output_pairing_id function."""
-    output_id, value = base_instance.get_output_by_pairing_id(256)
+def test_get_output_by_pairing(base_instance):
+    """Test the get_output_pairing function."""
+    output_id, value = base_instance.get_output_by_pairing(Pairing.AL_INFO_ON_OFF)
     assert output_id == "odp0000"
     assert value == "0"
 
-    with pytest.raises(InvalidDeviceChannelPairingId):
-        base_instance.get_output_by_pairing_id(99)
+    with pytest.raises(InvalidDeviceChannelPairing):
+        base_instance.get_output_by_pairing(Pairing.AL_HSV)
 
 
 def test_register_callback(base_instance):

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -7,7 +7,7 @@ from abbfreeathome.exceptions import (
     ForbiddenAuthException,
     InvalidApiResponseException,
     InvalidCredentialsException,
-    InvalidDeviceChannelPairingId,
+    InvalidDeviceChannelPairing,
     InvalidHostException,
     SetDatapointFailureException,
     UserNotFoundException,
@@ -54,10 +54,10 @@ def test_invalid_api_response_exception():
     assert str(excinfo.value) == "Invalid api response, status code: 404"
 
 
-def test_invalid_device_channel_pairing_id():
+def test_invalid_device_channel_pairing():
     """Test invalid device channel exception."""
-    with pytest.raises(InvalidDeviceChannelPairingId) as excinfo:
-        raise InvalidDeviceChannelPairingId("device1", "channel1", 123)
+    with pytest.raises(InvalidDeviceChannelPairing) as excinfo:
+        raise InvalidDeviceChannelPairing("device1", "channel1", 123)
     assert str(excinfo.value) == (
         "Could not find paring id for "
         "device: device1; channel: channel1; pairing id: 123"

--- a/tests/test_freeathome.py
+++ b/tests/test_freeathome.py
@@ -5,7 +5,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from abbfreeathome.api import FreeAtHomeApi
-from abbfreeathome.bin.function_id import FunctionID
+from abbfreeathome.bin.function import Function
 from abbfreeathome.bin.interface import Interface
 from abbfreeathome.devices.switch_actuator import SwitchActuator
 from abbfreeathome.freeathome import FreeAtHome
@@ -194,7 +194,7 @@ async def test_get_config(freeathome, api_mock):
 @pytest.mark.asyncio
 async def test_get_devices_by_function(freeathome):
     """Test the get_devices_by_fuction function."""
-    devices = await freeathome.get_devices_by_function(FunctionID.FID_SWITCH_ACTUATOR)
+    devices = await freeathome.get_devices_by_function(Function.FID_SWITCH_ACTUATOR)
     assert len(devices) == 2
     assert devices[0]["device_name"] == "Study Area Rocker"
     assert devices[0]["channel_name"] == "Study Area Light"


### PR DESCRIPTION
This PR refactors the ENUM's to remove the `id` naming convention.

- `FunctionID` --> `Function`
- `ParingID` --> `Pairing`

ID becomes a bit confusing as it's not an ID, it's an ENUM and the value is an ID.

I've also changed the FreeAtHome object to expose `self._api` as a public attribute `self.api` in case we would need to use the api externally (e.g. Home Assistant using the FreeAtHome class to fetch a value from the API). I don't have a use case yet but it's possible.