### PR TITLE
Optimize callbacks to reduce noise

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -48,13 +48,6 @@ jobs:
           format: markdown
           output: both
 
-      - name: Add Coverage PR Comment
-        uses: marocchino/sticky-pull-request-comment@v2
-        if: github.event_name == 'pull_request'
-        with:
-          hide_and_recreate: true
-          path: code-coverage-results.md
-
       - name: Write Coverage to Job Summary
         run: cat code-coverage-results.md >> $GITHUB_STEP_SUMMARY
 
@@ -64,4 +57,4 @@ jobs:
         with:
           report_paths: junit/test-results.xml
           detailed_summary: true
-          comment: true
+          comment: false

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -51,6 +51,7 @@ jobs:
           thresholds: '100 100'
 
       - name: Write Coverage to Job Summary
+        if: success() || failure() # always run even if the previous step fails
         run: cat code-coverage-results.md >> $GITHUB_STEP_SUMMARY
 
       - name: Publish Test Report

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -47,6 +47,8 @@ jobs:
           badge: true
           format: markdown
           output: both
+          fail_below_min: true
+          thresholds: '100 100'
 
       - name: Write Coverage to Job Summary
         run: cat code-coverage-results.md >> $GITHUB_STEP_SUMMARY

--- a/tests/test_switch_actuator.py
+++ b/tests/test_switch_actuator.py
@@ -95,4 +95,8 @@ def test_update_device(switch_actuator):
     switch_actuator.update_device("AL_INFO_ON_OFF/odp0000", "0")
     assert switch_actuator.state is False
 
+    # Test scenario where websocket sends update not relevant to the state.
+    switch_actuator.update_device("AL_INFO_ON_OFF/odp0001", "1")
+    assert switch_actuator.state is False
+
     switch_actuator.update_device("AL_INFO_ON_OFF/idp0000", "1")

--- a/tests/test_switch_actuator.py
+++ b/tests/test_switch_actuator.py
@@ -89,6 +89,13 @@ async def test_refresh_state(switch_actuator):
 
 def test_update_device(switch_actuator):
     """Test updating the device state."""
+
+    def test_callback():
+        pass
+
+    # Ensure callback is registered to test callback code.
+    switch_actuator.register_callback(test_callback)
+
     switch_actuator.update_device("AL_INFO_ON_OFF/odp0000", "1")
     assert switch_actuator.state is True
 


### PR DESCRIPTION
While implementing a new device I noticed a few things that could be improved in the `Base` class.

- The callbacks were being called after every update, regardless of whether the devices state was actually updated. If a device has multiple outputs that are updated it would run the callbacks for each update, even if just one of those updated the state.
- Declaring the `_callbacks = set()` at the class level was causing the callbacks to be shared between all instances of the class. Which would then add callbacks to devices that were not intended to have them.

This PR adds new classes `_refresh_state_from_output` and `_refresh_state_from_input` to handle the state updates and only call the callbacks if the state was actually updated.
I've moved the `update_device` logic to the `Base` class as that logic is generally the same between devices, but can be overwritten.
Adds an additional test to test the scenario where the websocket would send a device update that doesn't affect the state of the device.