### PR TITLE
Add movement detector device

### DIFF
--- a/src/abbfreeathome/devices/base.py
+++ b/src/abbfreeathome/devices/base.py
@@ -129,3 +129,5 @@ class Base:
 
     def _refresh_state_from_outputs(self):
         """Refresh the state of the device from the _outputs."""
+        for _output in self._outputs.values():
+            self._refresh_state_from_output(_output)

--- a/src/abbfreeathome/devices/movement_detector.py
+++ b/src/abbfreeathome/devices/movement_detector.py
@@ -43,6 +43,11 @@ class MovementDetector(Base):
         self._refresh_state_from_outputs()
 
     @property
+    def state(self) -> float:
+        """Get the movement state."""
+        return self._state
+
+    @property
     def brightness(self) -> float:
         """Get the brightness level of the sensor."""
         return float(self._brightness)
@@ -69,14 +74,10 @@ class MovementDetector(Base):
 
         This will return whether the state was refreshed as a boolean value.
         """
+        if output.get("pairingID") == Pairing.AL_TIMED_MOVEMENT.value:
+            self._state = output.get("value") == "1"
+            return True
         if output.get("pairingID") == Pairing.AL_BRIGHTNESS_LEVEL.value:
             self._brightness = output.get("value")
             return True
         return False
-
-    def _refresh_state_from_outputs(self):
-        """Refresh the state of the switch from the _outputs."""
-        _switch_output_id, _switch_output_value = self.get_output_by_pairing(
-            pairing=Pairing.AL_BRIGHTNESS_LEVEL
-        )
-        self._brightness = _switch_output_value

--- a/src/abbfreeathome/devices/movement_detector.py
+++ b/src/abbfreeathome/devices/movement_detector.py
@@ -43,9 +43,9 @@ class MovementDetector(Base):
         self._refresh_state_from_outputs()
 
     @property
-    def brightness(self):
+    def brightness(self) -> float:
         """Get the brightness level of the sensor."""
-        return self._brightness
+        return float(self._brightness)
 
     async def refresh_state(self):
         """Refresh the state of the device from the api."""

--- a/src/abbfreeathome/devices/movement_detector.py
+++ b/src/abbfreeathome/devices/movement_detector.py
@@ -1,0 +1,82 @@
+"""Free@Home MovementDetectorSensor Class."""
+
+from typing import Any
+
+from ..api import FreeAtHomeApi
+from ..bin.pairing import Pairing
+from .base import Base
+
+
+class MovementDetector(Base):
+    """Free@Home SwitchActuator Class."""
+
+    _state = None
+
+    def __init__(
+        self,
+        device_id: str,
+        device_name: str,
+        channel_id: str,
+        channel_name: str,
+        inputs: dict[str, dict[str, Any]],
+        outputs: dict[str, dict[str, Any]],
+        parameters: dict[str, dict[str, Any]],
+        api: FreeAtHomeApi,
+        floor_name: str | None = None,
+        room_name: str | None = None,
+    ) -> None:
+        """Initialize the Free@Home SwitchActuator class."""
+        super().__init__(
+            device_id,
+            device_name,
+            channel_id,
+            channel_name,
+            inputs,
+            outputs,
+            parameters,
+            api,
+            floor_name,
+            room_name,
+        )
+
+        # Set the initial state of the switch based on output
+        self._refresh_state_from_outputs()
+
+    @property
+    def brightness(self):
+        """Get the brightness level of the sensor."""
+        return self._brightness
+
+    async def refresh_state(self):
+        """Refresh the state of the device from the api."""
+        _switch_output_id, _switch_output_value = self.get_output_by_pairing(
+            pairing=Pairing.AL_BRIGHTNESS_LEVEL
+        )
+
+        _datapoint = (
+            await self._api.get_datapoint(
+                device_id=self.device_id,
+                channel_id=self.channel_id,
+                datapoint=_switch_output_id,
+            )
+        )[0]
+
+        self._brightness = _datapoint
+
+    def _refresh_state_from_output(self, output: dict[str, Any]) -> bool:
+        """
+        Refresh the state of the device from a given output.
+
+        This will return whether the state was refreshed as a boolean value.
+        """
+        if output.get("pairingID") == Pairing.AL_BRIGHTNESS_LEVEL.value:
+            self._brightness = output.get("value")
+            return True
+        return False
+
+    def _refresh_state_from_outputs(self):
+        """Refresh the state of the switch from the _outputs."""
+        _switch_output_id, _switch_output_value = self.get_output_by_pairing(
+            pairing=Pairing.AL_BRIGHTNESS_LEVEL
+        )
+        self._brightness = _switch_output_value

--- a/src/abbfreeathome/devices/movement_detector.py
+++ b/src/abbfreeathome/devices/movement_detector.py
@@ -54,19 +54,30 @@ class MovementDetector(Base):
 
     async def refresh_state(self):
         """Refresh the state of the device from the api."""
-        _switch_output_id, _switch_output_value = self.get_output_by_pairing(
-            pairing=Pairing.AL_BRIGHTNESS_LEVEL
-        )
+        _state_refresh_pairings = [
+            Pairing.AL_BRIGHTNESS_LEVEL,
+            Pairing.AL_TIMED_MOVEMENT,
+        ]
 
-        _datapoint = (
-            await self._api.get_datapoint(
-                device_id=self.device_id,
-                channel_id=self.channel_id,
-                datapoint=_switch_output_id,
+        for _pairing in _state_refresh_pairings:
+            _switch_output_id, _switch_output_value = self.get_output_by_pairing(
+                pairing=_pairing
             )
-        )[0]
 
-        self._brightness = _datapoint
+            _datapoint = (
+                await self._api.get_datapoint(
+                    device_id=self.device_id,
+                    channel_id=self.channel_id,
+                    datapoint=_switch_output_id,
+                )
+            )[0]
+
+            self._refresh_state_from_output(
+                output={
+                    "pairingID": _pairing.value,
+                    "value": _datapoint,
+                }
+            )
 
     def _refresh_state_from_output(self, output: dict[str, Any]) -> bool:
         """

--- a/src/abbfreeathome/devices/switch_actuator.py
+++ b/src/abbfreeathome/devices/switch_actuator.py
@@ -95,7 +95,7 @@ class SwitchActuator(Base):
         return False
 
     async def _set_switching_datapoint(self, value: str):
-        """Set the switching datapoing on the api."""
+        """Set the switching datapoint on the api."""
         _switch_input_id, _switch_input_value = self.get_input_by_pairing(
             pairing=Pairing.AL_SWITCH_ON_OFF
         )

--- a/src/abbfreeathome/devices/switch_actuator.py
+++ b/src/abbfreeathome/devices/switch_actuator.py
@@ -58,20 +58,30 @@ class SwitchActuator(Base):
         self._state = False
 
     async def refresh_state(self):
-        """Refresh the state of the switch from the api."""
-        _switch_output_id, _switch_output_value = self.get_output_by_pairing(
-            pairing=Pairing.AL_INFO_ON_OFF
-        )
+        """Refresh the state of the device from the api."""
+        _state_refresh_pairings = [
+            Pairing.AL_INFO_ON_OFF,
+        ]
 
-        _datapoint = (
-            await self._api.get_datapoint(
-                device_id=self.device_id,
-                channel_id=self.channel_id,
-                datapoint=_switch_output_id,
+        for _pairing in _state_refresh_pairings:
+            _switch_output_id, _switch_output_value = self.get_output_by_pairing(
+                pairing=_pairing
             )
-        )[0]
 
-        self._state = _datapoint == "1"
+            _datapoint = (
+                await self._api.get_datapoint(
+                    device_id=self.device_id,
+                    channel_id=self.channel_id,
+                    datapoint=_switch_output_id,
+                )
+            )[0]
+
+            self._refresh_state_from_output(
+                output={
+                    "pairingID": _pairing.value,
+                    "value": _datapoint,
+                }
+            )
 
     def _refresh_state_from_output(self, output: dict[str, Any]) -> bool:
         """

--- a/src/abbfreeathome/devices/switch_actuator.py
+++ b/src/abbfreeathome/devices/switch_actuator.py
@@ -84,14 +84,8 @@ class SwitchActuator(Base):
             return True
         return False
 
-    def _refresh_state_from_outputs(self):
-        """Refresh the state of the switch from the _outputs."""
-        _switch_output_id, _switch_output_value = self.get_output_by_pairing(
-            pairing=Pairing.AL_INFO_ON_OFF
-        )
-        self._state = _switch_output_value == "1"
-
     async def _set_switching_datapoint(self, value: str):
+        """Set the switching datapoing on the api."""
         _switch_input_id, _switch_input_value = self.get_input_by_pairing(
             pairing=Pairing.AL_SWITCH_ON_OFF
         )

--- a/src/abbfreeathome/freeathome.py
+++ b/src/abbfreeathome/freeathome.py
@@ -3,7 +3,9 @@
 from .api import FreeAtHomeApi
 from .bin.function import Function
 from .bin.interface import Interface
-from .devices.switch_actuator import Base, SwitchActuator
+from .devices.base import Base
+from .devices.movement_detector import MovementDetector
+from .devices.switch_actuator import SwitchActuator
 
 
 class FreeAtHome:
@@ -114,6 +116,11 @@ class FreeAtHome:
         # SwitchActuator
         await self._load_devices_by_function(
             Function.FID_SWITCH_ACTUATOR, SwitchActuator
+        )
+
+        # MovementDetector
+        await self._load_devices_by_function(
+            Function.FID_MOVEMENT_DETECTOR, MovementDetector
         )
 
     async def _load_devices_by_function(self, function: Function, device_class: Base):

--- a/tests/test_movement_detector.py
+++ b/tests/test_movement_detector.py
@@ -40,6 +40,7 @@ def movement_detector(mock_api):
 @pytest.mark.asyncio
 async def test_initial_state(movement_detector):
     """Test the intial state of the switch."""
+    assert movement_detector.state is False
     assert movement_detector.brightness == 1.6
 
 
@@ -58,6 +59,11 @@ async def test_refresh_state(movement_detector):
 
 def test_refresh_state_from_output(movement_detector):
     """Test the _refresh_state_from_output function."""
+    # Check output that affects the state.
+    movement_detector._refresh_state_from_output(
+        output={"pairingID": 6, "value": "1"},
+    )
+    assert movement_detector.state is True
 
     # Check output that affects the state.
     movement_detector._refresh_state_from_output(

--- a/tests/test_movement_detector.py
+++ b/tests/test_movement_detector.py
@@ -40,7 +40,7 @@ def movement_detector(mock_api):
 @pytest.mark.asyncio
 async def test_initial_state(movement_detector):
     """Test the intial state of the switch."""
-    assert movement_detector.brightness == "1.6"
+    assert movement_detector.brightness == 1.6
 
 
 @pytest.mark.asyncio
@@ -48,7 +48,7 @@ async def test_refresh_state(movement_detector):
     """Test refreshing the state of the switch."""
     movement_detector._api.get_datapoint.return_value = ["72.0"]
     await movement_detector.refresh_state()
-    assert movement_detector.brightness == "72.0"
+    assert movement_detector.brightness == 72.0
     movement_detector._api.get_datapoint.assert_called_with(
         device_id="ABB7F500E17A",
         channel_id="ch0003",
@@ -63,10 +63,10 @@ def test_refresh_state_from_output(movement_detector):
     movement_detector._refresh_state_from_output(
         output={"pairingID": 1027, "value": "52.3"},
     )
-    assert movement_detector.brightness == "52.3"
+    assert movement_detector.brightness == 52.3
 
     # Check output that does NOT affect the state.
     movement_detector._refresh_state_from_output(
         output={"pairingID": 6, "value": "0"},
     )
-    assert movement_detector.brightness == "52.3"
+    assert movement_detector.brightness == 52.3

--- a/tests/test_movement_detector.py
+++ b/tests/test_movement_detector.py
@@ -47,13 +47,14 @@ async def test_initial_state(movement_detector):
 @pytest.mark.asyncio
 async def test_refresh_state(movement_detector):
     """Test refreshing the state of the switch."""
-    movement_detector._api.get_datapoint.return_value = ["72.0"]
+    movement_detector._api.get_datapoint.return_value = ["1"]
     await movement_detector.refresh_state()
-    assert movement_detector.brightness == 72.0
+    assert movement_detector.state is True
+    assert movement_detector.brightness == 1.0
     movement_detector._api.get_datapoint.assert_called_with(
         device_id="ABB7F500E17A",
         channel_id="ch0003",
-        datapoint="odp0002",
+        datapoint="odp0000",
     )
 
 

--- a/tests/test_movement_detector.py
+++ b/tests/test_movement_detector.py
@@ -1,0 +1,72 @@
+"""Test class to test the SwitchActuator device."""
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from abbfreeathome.api import FreeAtHomeApi
+from abbfreeathome.devices.movement_detector import MovementDetector
+
+
+@pytest.fixture
+def mock_api():
+    """Create a mock api function."""
+    return AsyncMock(spec=FreeAtHomeApi)
+
+
+@pytest.fixture
+def movement_detector(mock_api):
+    """Set up the switch instance for testing the SwitchActuator device."""
+    inputs = {"idp0000": {"pairingID": 256, "value": "0"}}
+    outputs = {
+        "odp0000": {"pairingID": 6, "value": "0"},
+        "odp0001": {"pairingID": 7, "value": "0"},
+        "odp0002": {"pairingID": 1027, "value": "1.6"},
+    }
+    parameters = {"par0034": "1", "par00d5": "100"}
+
+    return MovementDetector(
+        device_id="ABB7F500E17A",
+        device_name="Device Name",
+        channel_id="ch0003",
+        channel_name="Channel Name",
+        inputs=inputs,
+        outputs=outputs,
+        parameters=parameters,
+        api=mock_api,
+    )
+
+
+@pytest.mark.asyncio
+async def test_initial_state(movement_detector):
+    """Test the intial state of the switch."""
+    assert movement_detector.brightness == "1.6"
+
+
+@pytest.mark.asyncio
+async def test_refresh_state(movement_detector):
+    """Test refreshing the state of the switch."""
+    movement_detector._api.get_datapoint.return_value = ["72.0"]
+    await movement_detector.refresh_state()
+    assert movement_detector.brightness == "72.0"
+    movement_detector._api.get_datapoint.assert_called_with(
+        device_id="ABB7F500E17A",
+        channel_id="ch0003",
+        datapoint="odp0002",
+    )
+
+
+def test_refresh_state_from_output(movement_detector):
+    """Test the _refresh_state_from_output function."""
+
+    # Check output that affects the state.
+    movement_detector._refresh_state_from_output(
+        output={"pairingID": 1027, "value": "52.3"},
+    )
+    assert movement_detector.brightness == "52.3"
+
+    # Check output that does NOT affect the state.
+    movement_detector._refresh_state_from_output(
+        output={"pairingID": 6, "value": "0"},
+    )
+    assert movement_detector.brightness == "52.3"


### PR DESCRIPTION
This adds a new MovementDetector device.

Initially this PR only supports the brightness level of the device, a future PR to be added to include movement events.

This addresses https://github.com/kingsleyadam/local-abbfreeathome/issues/39