### PR TITLE
Refactor function to device mapping class

### DIFF
--- a/src/abbfreeathome/devices/switch_sensor.py
+++ b/src/abbfreeathome/devices/switch_sensor.py
@@ -43,7 +43,7 @@ class SwitchSensor(Base):
         self._refresh_state_from_outputs()
 
     @property
-    def state(self) -> float:
+    def state(self) -> bool:
         """Get the switch state."""
         return self._state
 


### PR DESCRIPTION
This code refactors how the device class is mapped to Free@Home function. And it adds in the ability to limit which classes you want to load. I added the limiter more for testing purposes. It reduces the noise on the websocket if we only focus on a single class. But this could be use in the future (maybe in Home Assistant, give the ability to select which class devices to setup?

I also saw a channel named `ⓑ` in my setup, add in a catch to fall-back to device name if this comes through.

`_function_to_device_mapping` could probably sit in a constants file, if this grows too big it can always be moved.