### PR TITLE
Adjust how unit tests are referencing module

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -34,13 +34,12 @@ jobs:
       - name: Test with pytest
         run: |
           pytest \
-            --doctest-modules \
-            --junitxml=junit/test-results.xml \
-            --cov=abbfreeathome \
+            --cov=. \
             --cov-report=xml:coverage/coverage.xml \
-            --cov-report=html:coverage/htmlcov
+            --junitxml=junit/test-results.xml 
 
       - name: Code Coverage Summary Report
+        id: coverage
         uses: irongut/CodeCoverageSummary@v1.3.0
         with:
           filename: coverage/coverage.xml
@@ -51,12 +50,12 @@ jobs:
           thresholds: '100 100'
 
       - name: Write Coverage to Job Summary
-        if: success() || failure() # always run even if the previous step fails
+        if: success() || steps.coverage.conclusion == 'failure'
         run: cat code-coverage-results.md >> $GITHUB_STEP_SUMMARY
 
       - name: Publish Test Report
         uses: mikepenz/action-junit-report@v5.0.0-a03
-        if: success() || failure() # always run even if the previous step fails
+        if: success() || failure()
         with:
           report_paths: junit/test-results.xml
           detailed_summary: true

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -16,13 +16,26 @@
             "name": "Module: abbfreeathome.api",
             "type": "debugpy",
             "request": "launch",
-            "module": "src.abbfreeathome.api"
+            "module": "src.abbfreeathome.api",
+            "justMyCode": false
         },
         {
             "name": "Module: abbfreeathome.freeathome",
             "type": "debugpy",
             "request": "launch",
-            "module": "src.abbfreeathome.freeathome"
+            "module": "src.abbfreeathome.freeathome",
+            "justMyCode": false
+        },
+        {
+            "name": "Python: Debug Tests",
+            "type": "debugpy",
+            "request": "launch",
+            "program": "${file}",
+            "purpose": [
+                "debug-test"
+            ],
+            "console": "integratedTerminal",
+            "justMyCode": false
         }
     ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,6 @@
 {
     "python.testing.pytestArgs": [
-        "."
+        "tests"
     ],
     "python.testing.unittestEnabled": false,
     "python.testing.pytestEnabled": true

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,6 @@
 {
     "python.testing.pytestArgs": [
-        "tests"
+        "."
     ],
     "python.testing.unittestEnabled": false,
     "python.testing.pytestEnabled": true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -160,3 +160,9 @@ max-complexity = 25
 
 [tool.pytest.ini_options]
 asyncio_default_fixture_loop_scope = "function"
+pythonpath = [
+  "."
+]
+
+[tool.coverage.run]
+omit = ["*/test*"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -165,4 +165,4 @@ pythonpath = [
 ]
 
 [tool.coverage.run]
-omit = ["*/test*"]
+omit = ["*/tests/*"]

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -6,8 +6,8 @@ import aiohttp
 from aioresponses import aioresponses
 import pytest
 
-from abbfreeathome.api import FreeAtHomeApi, FreeAtHomeSettings
-from abbfreeathome.exceptions import (
+from src.abbfreeathome.api import FreeAtHomeApi, FreeAtHomeSettings
+from src.abbfreeathome.exceptions import (
     ConnectionTimeoutException,
     ForbiddenAuthException,
     InvalidApiResponseException,

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -4,10 +4,10 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from abbfreeathome.api import FreeAtHomeApi
-from abbfreeathome.bin.pairing import Pairing
-from abbfreeathome.devices.base import Base
-from abbfreeathome.exceptions import InvalidDeviceChannelPairing
+from src.abbfreeathome.api import FreeAtHomeApi
+from src.abbfreeathome.bin.pairing import Pairing
+from src.abbfreeathome.devices.base import Base
+from src.abbfreeathome.exceptions import InvalidDeviceChannelPairing
 
 
 @pytest.fixture

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from abbfreeathome.exceptions import (
+from src.abbfreeathome.exceptions import (
     ConnectionTimeoutException,
     ForbiddenAuthException,
     InvalidApiResponseException,

--- a/tests/test_freeathome.py
+++ b/tests/test_freeathome.py
@@ -4,11 +4,11 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from abbfreeathome.api import FreeAtHomeApi
-from abbfreeathome.bin.function import Function
-from abbfreeathome.bin.interface import Interface
-from abbfreeathome.devices.switch_actuator import SwitchActuator
-from abbfreeathome.freeathome import FreeAtHome
+from src.abbfreeathome.api import FreeAtHomeApi
+from src.abbfreeathome.bin.function import Function
+from src.abbfreeathome.bin.interface import Interface
+from src.abbfreeathome.devices.switch_actuator import SwitchActuator
+from src.abbfreeathome.freeathome import FreeAtHome
 
 
 @pytest.fixture

--- a/tests/test_movement_detector.py
+++ b/tests/test_movement_detector.py
@@ -4,8 +4,8 @@ from unittest.mock import AsyncMock
 
 import pytest
 
-from abbfreeathome.api import FreeAtHomeApi
-from abbfreeathome.devices.movement_detector import MovementDetector
+from src.abbfreeathome.api import FreeAtHomeApi
+from src.abbfreeathome.devices.movement_detector import MovementDetector
 
 
 @pytest.fixture

--- a/tests/test_switch_actuator.py
+++ b/tests/test_switch_actuator.py
@@ -4,8 +4,8 @@ from unittest.mock import AsyncMock
 
 import pytest
 
-from abbfreeathome.api import FreeAtHomeApi
-from abbfreeathome.devices.switch_actuator import SwitchActuator
+from src.abbfreeathome.api import FreeAtHomeApi
+from src.abbfreeathome.devices.switch_actuator import SwitchActuator
 
 
 @pytest.fixture

--- a/tests/test_switch_sensor.py
+++ b/tests/test_switch_sensor.py
@@ -4,8 +4,8 @@ from unittest.mock import AsyncMock
 
 import pytest
 
-from abbfreeathome.api import FreeAtHomeApi
-from abbfreeathome.devices.switch_sensor import SwitchSensor
+from src.abbfreeathome.api import FreeAtHomeApi
+from src.abbfreeathome.devices.switch_sensor import SwitchSensor
 
 
 @pytest.fixture

--- a/tests/test_trigger.py
+++ b/tests/test_trigger.py
@@ -4,8 +4,8 @@ from unittest.mock import AsyncMock
 
 import pytest
 
-from abbfreeathome.api import FreeAtHomeApi
-from abbfreeathome.devices.trigger import Trigger
+from src.abbfreeathome.api import FreeAtHomeApi
+from src.abbfreeathome.devices.trigger import Trigger
 
 
 @pytest.fixture


### PR DESCRIPTION
This PR adjusts how unit tests are run against the PyPi module. Previously I was referencing the `abbfreeathome` module, which requires you to install the module e.g. `abbfreeathome.api import FreeAtHomeApi`.

Instead, if I adjust the test `pythonpath` pytest option I can reference the module relative to the root path e.g. `src.abbfreeathome.api import FreeAtHomeApi`. This will run the tests against the files in the repo directly, instead of the installed module.

This has a number of benefits.

- Don't have to install the module in your python environment everytime you want to run a test.
- Natively works in Visual Studio Code, no need to run any Terminal Commands. This includes code coverage in Visual Studio Code.

I also adjusted the launch.json config to add a new debug configuration. This will allow you to Debug tests and step into the module code. This is much needed when attempting to figure out why a test isn't working, or why the test coverage isn't hitting all code paths.

#### Visual Studio Code

##### Run Tests

![Screenshot 2024-10-18 at 12 03 30](https://github.com/user-attachments/assets/02c55bdc-b0ee-420e-8523-806d5fc31c02)

##### Run Tests With Coverage

![Screenshot 2024-10-18 at 12 04 21](https://github.com/user-attachments/assets/5a71a3c4-af94-4c8c-96af-c6078e74a3fc)
