### PR TITLE
Make a number of refactors to how the state of devices is set.

### DIFF
--- a/src/abbfreeathome/devices/base.py
+++ b/src/abbfreeathome/devices/base.py
@@ -14,6 +14,9 @@ _LOGGER = logging.getLogger(__name__)
 class Base:
     """Free@Home Base Class."""
 
+    _state_refresh_output_pairings: list[Pairing] = []
+    _state_refresh_input_pairings: list[Pairing] = []
+
     def __init__(
         self,
         device_id: str,
@@ -39,6 +42,9 @@ class Base:
         self._floor_name = floor_name
         self._room_name = room_name
         self._callbacks = set()
+
+        # Set the initial state of the switch based on output
+        self._refresh_state_from_outputs()
 
     @property
     def device_id(self) -> str:
@@ -117,6 +123,28 @@ class Base:
     def remove_callback(self, callback: Callable[[], None]) -> None:
         """Remove previously registered callback."""
         self._callbacks.discard(callback)
+
+    async def refresh_state(self):
+        """Refresh the state of the device from the api."""
+        for _pairing in self._state_refresh_output_pairings:
+            _switch_output_id, _switch_output_value = self.get_output_by_pairing(
+                pairing=_pairing
+            )
+
+            _datapoint = (
+                await self._api.get_datapoint(
+                    device_id=self.device_id,
+                    channel_id=self.channel_id,
+                    datapoint=_switch_output_id,
+                )
+            )[0]
+
+            self._refresh_state_from_output(
+                output={
+                    "pairingID": _pairing.value,
+                    "value": _datapoint,
+                }
+            )
 
     def _refresh_state_from_input(self, input: dict[str, Any]) -> bool:
         """Refresh the state of the device a single input."""

--- a/src/abbfreeathome/devices/base.py
+++ b/src/abbfreeathome/devices/base.py
@@ -43,7 +43,7 @@ class Base:
         self._room_name = room_name
         self._callbacks = set()
 
-        # Set the initial state of the switch based on output
+        # Set the initial state of the device based on output
         self._refresh_state_from_outputs()
 
     @property
@@ -117,7 +117,7 @@ class Base:
                 callback()
 
     def register_callback(self, callback: Callable[[], None]) -> None:
-        """Register callback, called when switch changes state."""
+        """Register callback, called when device changes state."""
         self._callbacks.add(callback)
 
     def remove_callback(self, callback: Callable[[], None]) -> None:
@@ -127,15 +127,13 @@ class Base:
     async def refresh_state(self):
         """Refresh the state of the device from the api."""
         for _pairing in self._state_refresh_output_pairings:
-            _switch_output_id, _switch_output_value = self.get_output_by_pairing(
-                pairing=_pairing
-            )
+            _output_id, _output_value = self.get_output_by_pairing(pairing=_pairing)
 
             _datapoint = (
                 await self._api.get_datapoint(
                     device_id=self.device_id,
                     channel_id=self.channel_id,
-                    datapoint=_switch_output_id,
+                    datapoint=_output_id,
                 )
             )[0]
 

--- a/src/abbfreeathome/devices/dimming_actuator.py
+++ b/src/abbfreeathome/devices/dimming_actuator.py
@@ -10,8 +10,10 @@ from .base import Base
 class DimmingActuator(Base):
     """Free@Home DimmingActuator Class."""
 
-    _state = None
-    _brightness = None
+    _state_refresh_output_pairings: list[Pairing] = [
+        Pairing.AL_INFO_ON_OFF,
+        Pairing.AL_INFO_ACTUAL_DIMMING_VALUE,
+    ]
 
     def __init__(
         self,
@@ -27,6 +29,9 @@ class DimmingActuator(Base):
         room_name: str | None = None,
     ) -> None:
         """Initialize the Free@Home DimmingActuator class."""
+        self._state: bool | None = None
+        self._brightness: int | None = None
+
         super().__init__(
             device_id,
             device_name,
@@ -39,9 +44,6 @@ class DimmingActuator(Base):
             floor_name,
             room_name,
         )
-
-        # Set the initial state of the switch based on output
-        self._refresh_state_from_outputs()
 
     @property
     def state(self) -> bool:
@@ -75,33 +77,6 @@ class DimmingActuator(Base):
 
         await self._set_brightness_datapoint(str(value))
         self._brightness = value
-
-    async def refresh_state(self):
-        """Refresh the state of the device from the api."""
-        _state_refresh_pairings = [
-            Pairing.AL_INFO_ON_OFF,
-            Pairing.AL_INFO_ACTUAL_DIMMING_VALUE,
-        ]
-
-        for _pairing in _state_refresh_pairings:
-            _switch_output_id, _switch_output_value = self.get_output_by_pairing(
-                pairing=_pairing
-            )
-
-            _datapoint = (
-                await self._api.get_datapoint(
-                    device_id=self.device_id,
-                    channel_id=self.channel_id,
-                    datapoint=_switch_output_id,
-                )
-            )[0]
-
-            self._refresh_state_from_output(
-                output={
-                    "pairingID": _pairing.value,
-                    "value": _datapoint,
-                }
-            )
 
     def _refresh_state_from_output(self, output: dict[str, Any]) -> bool:
         """

--- a/src/abbfreeathome/devices/switch_actuator.py
+++ b/src/abbfreeathome/devices/switch_actuator.py
@@ -10,7 +10,9 @@ from .base import Base
 class SwitchActuator(Base):
     """Free@Home SwitchActuator Class."""
 
-    _state = None
+    _state_refresh_output_pairings: list[Pairing] = [
+        Pairing.AL_INFO_ON_OFF,
+    ]
 
     def __init__(
         self,
@@ -26,6 +28,8 @@ class SwitchActuator(Base):
         room_name: str | None = None,
     ) -> None:
         """Initialize the Free@Home SwitchActuator class."""
+        self._state: bool | None = None
+
         super().__init__(
             device_id,
             device_name,
@@ -38,9 +42,6 @@ class SwitchActuator(Base):
             floor_name,
             room_name,
         )
-
-        # Set the initial state of the switch based on output
-        self._refresh_state_from_outputs()
 
     @property
     def state(self) -> bool | None:
@@ -56,32 +57,6 @@ class SwitchActuator(Base):
         """Turn on the switch."""
         await self._set_switching_datapoint("0")
         self._state = False
-
-    async def refresh_state(self):
-        """Refresh the state of the device from the api."""
-        _state_refresh_pairings = [
-            Pairing.AL_INFO_ON_OFF,
-        ]
-
-        for _pairing in _state_refresh_pairings:
-            _switch_output_id, _switch_output_value = self.get_output_by_pairing(
-                pairing=_pairing
-            )
-
-            _datapoint = (
-                await self._api.get_datapoint(
-                    device_id=self.device_id,
-                    channel_id=self.channel_id,
-                    datapoint=_switch_output_id,
-                )
-            )[0]
-
-            self._refresh_state_from_output(
-                output={
-                    "pairingID": _pairing.value,
-                    "value": _datapoint,
-                }
-            )
 
     def _refresh_state_from_output(self, output: dict[str, Any]) -> bool:
         """

--- a/src/abbfreeathome/devices/switch_sensor.py
+++ b/src/abbfreeathome/devices/switch_sensor.py
@@ -10,7 +10,9 @@ from .base import Base
 class SwitchSensor(Base):
     """Free@Home SwitchSensor Class."""
 
-    _state = None
+    _state_refresh_output_pairings: list[Pairing] = [
+        Pairing.AL_SWITCH_ON_OFF,
+    ]
 
     def __init__(
         self,
@@ -26,6 +28,8 @@ class SwitchSensor(Base):
         room_name: str | None = None,
     ) -> None:
         """Initialize the Free@Home SwitchSensor class."""
+        self._state: bool | None = None
+
         super().__init__(
             device_id,
             device_name,
@@ -39,39 +43,10 @@ class SwitchSensor(Base):
             room_name,
         )
 
-        # Set the initial state of the switch based on output
-        self._refresh_state_from_outputs()
-
     @property
     def state(self) -> bool | None:
         """Get the switch state."""
         return self._state
-
-    async def refresh_state(self):
-        """Refresh the state of the device from the api."""
-        _state_refresh_pairings = [
-            Pairing.AL_SWITCH_ON_OFF,
-        ]
-
-        for _pairing in _state_refresh_pairings:
-            _switch_output_id, _switch_output_value = self.get_output_by_pairing(
-                pairing=_pairing
-            )
-
-            _datapoint = (
-                await self._api.get_datapoint(
-                    device_id=self.device_id,
-                    channel_id=self.channel_id,
-                    datapoint=_switch_output_id,
-                )
-            )[0]
-
-            self._refresh_state_from_output(
-                output={
-                    "pairingID": _pairing.value,
-                    "value": _datapoint,
-                }
-            )
 
     def _refresh_state_from_output(self, output: dict[str, Any]) -> bool:
         """

--- a/src/abbfreeathome/devices/window_door_sensor.py
+++ b/src/abbfreeathome/devices/window_door_sensor.py
@@ -10,7 +10,9 @@ from .base import Base
 class WindowDoorSensor(Base):
     """Free@Home WindowDoorSensor Class."""
 
-    _state = None
+    _state_refresh_output_pairings: list[Pairing] = [
+        Pairing.AL_WINDOW_DOOR,
+    ]
 
     def __init__(
         self,
@@ -26,6 +28,8 @@ class WindowDoorSensor(Base):
         room_name: str | None = None,
     ) -> None:
         """Initialize the Free@Home SwitchSensor class."""
+        self._state: bool | None = None
+
         super().__init__(
             device_id,
             device_name,
@@ -39,39 +43,10 @@ class WindowDoorSensor(Base):
             room_name,
         )
 
-        # Set the initial state of the switch based on output
-        self._refresh_state_from_outputs()
-
     @property
     def state(self) -> bool | None:
         """Get the sensor state."""
         return self._state
-
-    async def refresh_state(self):
-        """Refresh the state of the device from the api."""
-        _state_refresh_pairings = [
-            Pairing.AL_WINDOW_DOOR,
-        ]
-
-        for _pairing in _state_refresh_pairings:
-            _sensor_output_id, _sensor_output_value = self.get_output_by_pairing(
-                pairing=_pairing
-            )
-
-            _datapoint = (
-                await self._api.get_datapoint(
-                    device_id=self.device_id,
-                    channel_id=self.channel_id,
-                    datapoint=_sensor_output_id,
-                )
-            )[0]
-
-            self._refresh_state_from_output(
-                output={
-                    "pairingID": _pairing.value,
-                    "value": _datapoint,
-                }
-            )
 
     def _refresh_state_from_output(self, output: dict[str, Any]) -> bool:
         """

--- a/tests/test_movement_detector.py
+++ b/tests/test_movement_detector.py
@@ -8,15 +8,8 @@ from src.abbfreeathome.api import FreeAtHomeApi
 from src.abbfreeathome.devices.movement_detector import MovementDetector
 
 
-@pytest.fixture
-def mock_api():
-    """Create a mock api function."""
-    return AsyncMock(spec=FreeAtHomeApi)
-
-
-@pytest.fixture
-def movement_detector(mock_api):
-    """Set up the switch instance for testing the SwitchActuator device."""
+def get_movement_detector(type: str, mock_api):
+    """Get the MovementDetector class to be tested against."""
     inputs = {"idp0000": {"pairingID": 256, "value": "0"}}
     outputs = {
         "odp0000": {"pairingID": 6, "value": "0"},
@@ -24,6 +17,10 @@ def movement_detector(mock_api):
         "odp0002": {"pairingID": 1027, "value": "1.6"},
     }
     parameters = {"par0034": "1", "par00d5": "100"}
+
+    # If it's outdoor it won't have brightness
+    if type == "outdoor":
+        outputs.pop("odp0002")
 
     return MovementDetector(
         device_id="ABB7F500E17A",
@@ -37,43 +34,68 @@ def movement_detector(mock_api):
     )
 
 
+@pytest.fixture
+def mock_api():
+    """Create a mock api function."""
+    return AsyncMock(spec=FreeAtHomeApi)
+
+
+@pytest.fixture
+def movement_detector_indoor(mock_api):
+    """Set up the switch instance for testing the SwitchActuator device."""
+    return get_movement_detector("indoor", mock_api)
+
+
+@pytest.fixture
+def movement_detector_outdoor(mock_api):
+    """Set up the switch instance for testing the SwitchActuator device."""
+    return get_movement_detector("outdoor", mock_api)
+
+
 @pytest.mark.asyncio
-async def test_initial_state(movement_detector):
+async def test_initial_state_indoor(movement_detector_indoor):
     """Test the intial state of the switch."""
-    assert movement_detector.state is False
-    assert movement_detector.brightness == 1.6
+    assert movement_detector_indoor.state is False
+    assert movement_detector_indoor.brightness == 1.6
 
 
 @pytest.mark.asyncio
-async def test_refresh_state(movement_detector):
+async def test_initial_state_outdoor(movement_detector_outdoor):
+    """Test the intial state of the switch."""
+    assert movement_detector_outdoor.state is False
+    assert movement_detector_outdoor.brightness is None
+
+
+@pytest.mark.asyncio
+async def test_refresh_state(movement_detector_indoor):
     """Test refreshing the state of the switch."""
-    movement_detector._api.get_datapoint.return_value = ["1"]
-    await movement_detector.refresh_state()
-    assert movement_detector.state is True
-    assert movement_detector.brightness == 1.0
-    movement_detector._api.get_datapoint.assert_called_with(
+    movement_detector_indoor._api.get_datapoint.return_value = ["1"]
+    await movement_detector_indoor.refresh_state()
+    assert movement_detector_indoor.state is True
+    assert movement_detector_indoor.brightness == 1.0
+    movement_detector_indoor._api.get_datapoint.assert_called_with(
         device_id="ABB7F500E17A",
         channel_id="ch0003",
         datapoint="odp0000",
     )
 
 
-def test_refresh_state_from_output(movement_detector):
+def test_refresh_state_from_output(movement_detector_indoor):
     """Test the _refresh_state_from_output function."""
     # Check output that affects the state.
-    movement_detector._refresh_state_from_output(
+    movement_detector_indoor._refresh_state_from_output(
         output={"pairingID": 6, "value": "1"},
     )
-    assert movement_detector.state is True
+    assert movement_detector_indoor.state is True
 
     # Check output that affects the state.
-    movement_detector._refresh_state_from_output(
+    movement_detector_indoor._refresh_state_from_output(
         output={"pairingID": 1027, "value": "52.3"},
     )
-    assert movement_detector.brightness == 52.3
+    assert movement_detector_indoor.brightness == 52.3
 
     # Check output that does NOT affect the state.
-    movement_detector._refresh_state_from_output(
+    movement_detector_indoor._refresh_state_from_output(
         output={"pairingID": 6, "value": "0"},
     )
-    assert movement_detector.brightness == 52.3
+    assert movement_detector_indoor.brightness == 52.3


### PR DESCRIPTION
This is a refactor to how the state of devices is set. This should reduce the amount of duplicate code. Thanks @derjoerg for the suggestions on this one.

- Add new `_state_refresh_output_pairings` and `_state_refresh_input_pairings` to the `Base` class to store the pairings for refreshing the state of the device.
- Move `self._refresh_state_from_outputs()` to the Base class as we have to run this on each initialization of a device.
- Move the `refresh_state` function into the Base class and use the new `_state_refresh_output_pairings` to update the device state.
- For each device class move the `_state` and `_brightness` (if it exists) initial setter to the `__init__` of the class itself. This should ensure the devices state properties always have a value, with an initial value of `None`.
- For the movment_detector class, it's possible it won't have brightness. Add a new test case where a movement detector doesn't have brightness but ensure the state of brightness is still set to a None value.