### PR TITLE
Add ability to unload device

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ packages = ["src/abbfreeathome"]
 
 [project]
 name = "local-abbfreeathome"
-version = "1.8.0"
+version = "1.8.1"
 authors = [
   { name="Adam Kingsley", email="adam@kingsley.io" },
 ]

--- a/src/abbfreeathome/freeathome.py
+++ b/src/abbfreeathome/freeathome.py
@@ -139,6 +139,15 @@ class FreeAtHome:
                 _mapping.get("function"), _mapping.get("device_class")
             )
 
+    def unload_device_by_device_serial(self, device_serial: str):
+        """Unload all devices by device serial id."""
+        for key in [
+            _device
+            for _device in self._devices
+            if _device.split("/")[0] == device_serial
+        ]:
+            self._devices.pop(key)
+
     async def _load_devices_by_function(self, function: Function, device_class: Base):
         _devices = await self.get_devices_by_function(function)
         for _device in _devices:

--- a/tests/test_freeathome.py
+++ b/tests/test_freeathome.py
@@ -344,6 +344,10 @@ async def test_load_devices(freeathome):
     assert freeathome._devices[device_key].floor_name == "Ground Floor"
     assert freeathome._devices[device_key].room_name == "Living Room"
 
+    # Unload a single device and test it's been removed
+    freeathome.unload_device_by_device_serial(device_serial="ABB7F62F6C0B")
+    assert len(freeathome._devices) == 2
+
 
 @pytest.mark.asyncio
 async def test_load_devices_with_orphans(freeathome_orphans):


### PR DESCRIPTION
This adds the ability to "unload" a device by device serial id. Required for us to be able to delete a device in Home Assistant.