### PR TITLE
Add additional WindowSensor with position

### DIFF
--- a/src/abbfreeathome/devices/window_door_sensor.py
+++ b/src/abbfreeathome/devices/window_door_sensor.py
@@ -11,10 +11,10 @@ from .base import Base
 class WindowDoorSensorPosition(enum.Enum):
     """An Enum class for window/door sensor possible positions."""
 
-    Unknown = None
-    Closed = "0"
-    Tilted = "33"
-    Open = "100"
+    UNKNOWN = None
+    CLOSED = "0"
+    TILTED = "33"
+    OPEN = "100"
 
 
 class WindowDoorSensor(Base):
@@ -39,7 +39,7 @@ class WindowDoorSensor(Base):
     ) -> None:
         """Initialize the Free@Home SwitchSensor class."""
         self._state: bool | None = None
-        self._position: WindowDoorSensorPosition = WindowDoorSensorPosition.Unknown
+        self._position: WindowDoorSensorPosition = WindowDoorSensorPosition.UNKNOWN
 
         super().__init__(
             device_id,
@@ -77,6 +77,6 @@ class WindowDoorSensor(Base):
             try:
                 self._position = WindowDoorSensorPosition(output.get("value"))
             except ValueError:
-                self._position = WindowDoorSensorPosition.Unknown
+                self._position = WindowDoorSensorPosition.UNKNOWN
             return True
         return False

--- a/src/abbfreeathome/devices/window_door_sensor.py
+++ b/src/abbfreeathome/devices/window_door_sensor.py
@@ -1,10 +1,20 @@
 """Free@Home WindowDoorSensor Class."""
 
+import enum
 from typing import Any
 
 from ..api import FreeAtHomeApi
 from ..bin.pairing import Pairing
 from .base import Base
+
+
+class WindowDoorSensorPosition(enum.Enum):
+    """An Enum class for window/door sensor possible positions."""
+
+    Unknown = None
+    Closed = "0"
+    Tilted = "33"
+    Open = "100"
 
 
 class WindowDoorSensor(Base):
@@ -29,6 +39,7 @@ class WindowDoorSensor(Base):
     ) -> None:
         """Initialize the Free@Home SwitchSensor class."""
         self._state: bool | None = None
+        self._position: WindowDoorSensorPosition = WindowDoorSensorPosition.Unknown
 
         super().__init__(
             device_id,
@@ -48,6 +59,11 @@ class WindowDoorSensor(Base):
         """Get the sensor state."""
         return self._state
 
+    @property
+    def position(self) -> str | None:
+        """Get the sensor position."""
+        return self._position.name
+
     def _refresh_state_from_output(self, output: dict[str, Any]) -> bool:
         """
         Refresh the state of the device from a given output.
@@ -56,5 +72,11 @@ class WindowDoorSensor(Base):
         """
         if output.get("pairingID") == Pairing.AL_WINDOW_DOOR.value:
             self._state = output.get("value") == "1"
+            return True
+        if output.get("pairingID") == Pairing.AL_WINDOW_DOOR_POSITION.value:
+            try:
+                self._position = WindowDoorSensorPosition(output.get("value"))
+            except ValueError:
+                self._position = WindowDoorSensorPosition.Unknown
             return True
         return False

--- a/src/abbfreeathome/freeathome.py
+++ b/src/abbfreeathome/freeathome.py
@@ -211,6 +211,10 @@ class FreeAtHome:
                 "device_class": WindowDoorSensor,
             },
             {
+                "function": Function.FID_WINDOW_DOOR_POSITION_SENSOR,
+                "device_class": WindowDoorSensor,
+            },
+            {
                 "function": Function.FID_DES_DOOR_RINGING_SENSOR,
                 "device_class": DesDoorRingingSensor,
             },

--- a/tests/test_window_door_sensor.py
+++ b/tests/test_window_door_sensor.py
@@ -19,8 +19,9 @@ def window_door_sensor(mock_api):
     """Set up the sensor instance for testing the WindowDoorSensor device."""
     inputs = {}
     outputs = {
-        "odp0000": {"pairingID": 53, "value": "0"},
+        "odp0000": {"pairingID": 53, "value": "1"},
         "odp0001": {"pairingID": 0, "value": "0"},
+        "odp0003": {"pairingID": 41, "value": "33"},
     }
     parameters = {"par0010": "2"}
 
@@ -39,7 +40,8 @@ def window_door_sensor(mock_api):
 @pytest.mark.asyncio
 async def test_initial_state(window_door_sensor):
     """Test the intial state of the window-door-sensor."""
-    assert window_door_sensor.state is False
+    assert window_door_sensor.state is True
+    assert window_door_sensor.position == "Tilted"
 
 
 @pytest.mark.asyncio
@@ -59,12 +61,22 @@ def test_refresh_state_from_output(window_door_sensor):
     """Test the _refresh_state_from_output function."""
     # Check output that affects the state.
     window_door_sensor._refresh_state_from_output(
-        output={"pairingID": 53, "value": "1"},
+        output={"pairingID": 53, "value": "0"},
     )
-    assert window_door_sensor.state is True
+    assert window_door_sensor.state is False
+
+    window_door_sensor._refresh_state_from_output(
+        output={"pairingID": 41, "value": "100"},
+    )
+    assert window_door_sensor.position == "Open"
+
+    window_door_sensor._refresh_state_from_output(
+        output={"pairingID": 41, "value": "NOTVALID"},
+    )
+    assert window_door_sensor.position == "Unknown"
 
     # Check output that NOT affects the state.
     window_door_sensor._refresh_state_from_output(
         output={"pairingID": 0, "value": "1"},
     )
-    assert window_door_sensor.state is True
+    assert window_door_sensor.state is False

--- a/tests/test_window_door_sensor.py
+++ b/tests/test_window_door_sensor.py
@@ -41,7 +41,7 @@ def window_door_sensor(mock_api):
 async def test_initial_state(window_door_sensor):
     """Test the intial state of the window-door-sensor."""
     assert window_door_sensor.state is True
-    assert window_door_sensor.position == "Tilted"
+    assert window_door_sensor.position == "TILTED"
 
 
 @pytest.mark.asyncio
@@ -68,12 +68,12 @@ def test_refresh_state_from_output(window_door_sensor):
     window_door_sensor._refresh_state_from_output(
         output={"pairingID": 41, "value": "100"},
     )
-    assert window_door_sensor.position == "Open"
+    assert window_door_sensor.position == "OPEN"
 
     window_door_sensor._refresh_state_from_output(
         output={"pairingID": 41, "value": "NOTVALID"},
     )
-    assert window_door_sensor.position == "Unknown"
+    assert window_door_sensor.position == "UNKNOWN"
 
     # Check output that NOT affects the state.
     window_door_sensor._refresh_state_from_output(


### PR DESCRIPTION
This addresses #66 

This adds an additional device with function `FID_WINDOW_DOOR_POSITION_SENSOR`. This has the same exact state of `FID_WINDOW_DOOR_SENSOR` but incorporates an additional window position sensor.

The position can either be Closed, Titled, or Open.

This implements an enum class to hold the byte values and their names.