### PR TITLE
Use lowercase for window position.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ packages = ["src/abbfreeathome"]
 
 [project]
 name = "local-abbfreeathome"
-version = "1.9.0"
+version = "1.9.1"
 authors = [
   { name="Adam Kingsley", email="adam@kingsley.io" },
 ]

--- a/src/abbfreeathome/devices/window_door_sensor.py
+++ b/src/abbfreeathome/devices/window_door_sensor.py
@@ -9,12 +9,16 @@ from .base import Base
 
 
 class WindowDoorSensorPosition(enum.Enum):
-    """An Enum class for window/door sensor possible positions."""
+    """
+    An Enum class for window/door sensor possible positions.
 
-    UNKNOWN = None
-    CLOSED = "0"
-    TILTED = "33"
-    OPEN = "100"
+    Home Assistant requires the name to be all lowercase.
+    """
+
+    unknown = None
+    closed = "0"
+    tilted = "33"
+    open = "100"
 
 
 class WindowDoorSensor(Base):
@@ -39,7 +43,7 @@ class WindowDoorSensor(Base):
     ) -> None:
         """Initialize the Free@Home SwitchSensor class."""
         self._state: bool | None = None
-        self._position: WindowDoorSensorPosition = WindowDoorSensorPosition.UNKNOWN
+        self._position: WindowDoorSensorPosition = WindowDoorSensorPosition.unknown
 
         super().__init__(
             device_id,
@@ -77,6 +81,6 @@ class WindowDoorSensor(Base):
             try:
                 self._position = WindowDoorSensorPosition(output.get("value"))
             except ValueError:
-                self._position = WindowDoorSensorPosition.UNKNOWN
+                self._position = WindowDoorSensorPosition.unknown
             return True
         return False

--- a/tests/test_window_door_sensor.py
+++ b/tests/test_window_door_sensor.py
@@ -41,7 +41,7 @@ def window_door_sensor(mock_api):
 async def test_initial_state(window_door_sensor):
     """Test the intial state of the window-door-sensor."""
     assert window_door_sensor.state is True
-    assert window_door_sensor.position == "TILTED"
+    assert window_door_sensor.position == "tilted"
 
 
 @pytest.mark.asyncio
@@ -68,12 +68,12 @@ def test_refresh_state_from_output(window_door_sensor):
     window_door_sensor._refresh_state_from_output(
         output={"pairingID": 41, "value": "100"},
     )
-    assert window_door_sensor.position == "OPEN"
+    assert window_door_sensor.position == "open"
 
     window_door_sensor._refresh_state_from_output(
         output={"pairingID": 41, "value": "NOTVALID"},
     )
-    assert window_door_sensor.position == "UNKNOWN"
+    assert window_door_sensor.position == "unknown"
 
     # Check output that NOT affects the state.
     window_door_sensor._refresh_state_from_output(


### PR DESCRIPTION
For #66 , Home Assistant requires the option names to be all lowercase.