### PR TITLE
Refactor/clean-up parts of the code

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ There an additional class called `FreeAtHome`. This class attempts to put it all
 
 ### Get Devices
 
-This example will load the `FreeAtHome` class with all potential devices from the api. Once loaded another function `get_device_by_class` is used to pull all devices that call under a specific "class".
+This example will load the `FreeAtHome` class with all potential devices from the api. Once loaded another function `get_devices_by_class` is used to pull all devices that call under a specific "class".
 
 ```python
 from abbfreeathome.api import FreeAtHomeApi
@@ -223,7 +223,7 @@ if __name__ == "__main__":
     asyncio.run(_free_at_home.load_devices())
 
     # Fetch just the list of switches
-    _switches = _free_at_home.get_device_by_class(device_class=SwitchActuator)
+    _switches = _free_at_home.get_devices_by_class(device_class=SwitchActuator)
 
     # Loop through each switch showing the name and whether is On/Off
     for _switch in _switches:
@@ -261,7 +261,7 @@ if __name__ == "__main__":
     asyncio.run(_free_at_home.load_devices())
 
     # Set the callback function on each switch.
-    for _switch in _free_at_home.get_device_by_class(device_class=SwitchActuator):
+    for _switch in _free_at_home.get_devices_by_class(device_class=SwitchActuator):
         _switch.register_callback(my_very_own_callback)
 
     # Start listenting

--- a/src/abbfreeathome/const.py
+++ b/src/abbfreeathome/const.py
@@ -1,0 +1,26 @@
+"""Constants for the FreeAtHome package."""
+
+from .bin.function import Function
+from .devices.base import Base
+from .devices.carbon_monoxide_sensor import CarbonMonoxideSensor
+from .devices.des_door_ringing_sensor import DesDoorRingingSensor
+from .devices.dimming_actuator import DimmingActuator
+from .devices.movement_detector import MovementDetector
+from .devices.smoke_detector import SmokeDetector
+from .devices.switch_actuator import SwitchActuator
+from .devices.switch_sensor import SwitchSensor
+from .devices.trigger import Trigger
+from .devices.window_door_sensor import WindowDoorSensor
+
+FUNCTION_DEVICE_MAPPING: dict[Function, Base] = {
+    Function.FID_CARBON_MONOXIDE_SENSOR: CarbonMonoxideSensor,
+    Function.FID_DES_DOOR_RINGING_SENSOR: DesDoorRingingSensor,
+    Function.FID_DIMMING_ACTUATOR: DimmingActuator,
+    Function.FID_MOVEMENT_DETECTOR: MovementDetector,
+    Function.FID_SMOKE_DETECTOR: SmokeDetector,
+    Function.FID_SWITCH_ACTUATOR: SwitchActuator,
+    Function.FID_SWITCH_SENSOR: SwitchSensor,
+    Function.FID_TRIGGER: Trigger,
+    Function.FID_WINDOW_DOOR_POSITION_SENSOR: WindowDoorSensor,
+    Function.FID_WINDOW_DOOR_SENSOR: WindowDoorSensor,
+}

--- a/tests/test_freeathome.py
+++ b/tests/test_freeathome.py
@@ -323,7 +323,7 @@ def test_get_device_by_class(freeathome):
     """Test the get_device_class function."""
     device = MagicMock(spec=SwitchActuator)
     freeathome._devices = {"device1": device}
-    devices = freeathome.get_device_by_class(SwitchActuator)
+    devices = freeathome.get_devices_by_class(SwitchActuator)
     assert devices == [device]
 
 
@@ -332,21 +332,25 @@ async def test_load_devices(freeathome):
     """Test the load_devices function."""
     await freeathome.load_devices()
 
+    # Get the dict of devices
+    devices = freeathome.get_devices()
+
     # Verify that the devices are loaded correctly
-    assert len(freeathome._devices) == 4
+    assert len(devices) == 4
 
     # Check a single device
     device_key = "ABB7F500E17A/ch0003"
-    assert device_key in freeathome._devices
-    assert isinstance(freeathome._devices[device_key], SwitchActuator)
-    assert freeathome._devices[device_key].device_name == "Study Area Rocker"
-    assert freeathome._devices[device_key].channel_name == "Study Area Light"
-    assert freeathome._devices[device_key].floor_name == "Ground Floor"
-    assert freeathome._devices[device_key].room_name == "Living Room"
+    assert device_key in devices
+    assert isinstance(devices[device_key], SwitchActuator)
+    assert devices[device_key].device_name == "Study Area Rocker"
+    assert devices[device_key].channel_name == "Study Area Light"
+    assert devices[device_key].floor_name == "Ground Floor"
+    assert devices[device_key].room_name == "Living Room"
 
     # Unload a single device and test it's been removed
     freeathome.unload_device_by_device_serial(device_serial="ABB7F62F6C0B")
-    assert len(freeathome._devices) == 2
+    devices = freeathome.get_devices()
+    assert len(devices) == 2
 
 
 @pytest.mark.asyncio
@@ -354,21 +358,20 @@ async def test_load_devices_with_orphans(freeathome_orphans):
     """Test the load_devices function."""
     await freeathome_orphans.load_devices()
 
+    # Get the dict of devices
+    devices = freeathome_orphans.get_devices()
+
     # Verify that the devices are loaded correctly
-    assert len(freeathome_orphans._devices) == 6
+    assert len(devices) == 6
 
     # Check a single orphan device
     device_key = "ABB28CBC3651/ch0006"
-    assert device_key in freeathome_orphans._devices
-    assert isinstance(freeathome_orphans._devices[device_key], SwitchSensor)
-    assert (
-        freeathome_orphans._devices[device_key].device_name == "Sensor/switch actuator"
-    )
-    assert (
-        freeathome_orphans._devices[device_key].channel_name == "Sensor/switch actuator"
-    )
-    assert freeathome_orphans._devices[device_key].floor_name is None
-    assert freeathome_orphans._devices[device_key].room_name is None
+    assert device_key in devices
+    assert isinstance(devices[device_key], SwitchSensor)
+    assert devices[device_key].device_name == "Sensor/switch actuator"
+    assert devices[device_key].channel_name == "Sensor/switch actuator"
+    assert devices[device_key].floor_name is None
+    assert devices[device_key].room_name is None
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
This runs a refactor/clean-up on a few parts of the code.

- Update `get_device_by_class` to `get_devices_by_class` to be consistent with other functions.
- Add new `get_devices()` public function to allow any external code to fetch the list of devices. Use this in tests.
- Move _config, _devices to init of the FreeAtHome class.
- Move the _function_to_device_mapping` to a new `const.py` file to clean-up and reduce the size of the FreeAtHome class.
- Use a dictionary to map `Function` to `Base` in the new `const.py` file instead of a list. This enforces a function can only be defined once, but a device class can be assigned to multiple functions.