### PR TITLE
Add event states to switch_sensor, ringing_sensor

### DIFF
--- a/src/abbfreeathome/devices/des_door_ringing_sensor.py
+++ b/src/abbfreeathome/devices/des_door_ringing_sensor.py
@@ -41,6 +41,16 @@ class DesDoorRingingSensor(Base):
             room_name,
         )
 
+    @property
+    def event_state(self) -> str:
+        """Get the event state of the sensor."""
+        return "Press"
+
+    @property
+    def event_state_types(self) -> list[str]:
+        """Get all possible event state types of the sensor."""
+        return ["Press"]
+
     def _refresh_state_from_output(self, output: dict[str, Any]) -> bool:
         """
         Refresh the state of the device from a given output.

--- a/src/abbfreeathome/devices/switch_sensor.py
+++ b/src/abbfreeathome/devices/switch_sensor.py
@@ -44,6 +44,16 @@ class SwitchSensor(Base):
         )
 
     @property
+    def event_state(self) -> str:
+        """Get the event type of the switch."""
+        return "On" if self.state else "Off"
+
+    @property
+    def event_state_types(self) -> list[str]:
+        """Get all possible event types of the switch."""
+        return ["On", "Off"]
+
+    @property
     def state(self) -> bool | None:
         """Get the switch state."""
         return self._state


### PR DESCRIPTION
This adds event type and current event state to the two classes that will even the event platform. For the event platform we need to know what the possible events are, and what the current event state is.

For the switch_sensor it's either on or off, the the door ringing sensor it'll always be "Press"

@derjoerg , let me know if "Press" isn't the correct term to use here, I assume this is for a doorbell button press?