### PR TITLE
Bugfix RTC-valve

### DIFF
--- a/src/abbfreeathome/devices/room_temperature_controller.py
+++ b/src/abbfreeathome/devices/room_temperature_controller.py
@@ -148,7 +148,10 @@ class RoomTemperatureController(Base):
             self._current_temperature = float(output.get("value"))
             return True
         if output.get("pairingID") == Pairing.AL_HEATING_DEMAND.value:
-            self._valve = int(output.get("value"))
+            try:
+                self._valve = int(output.get("value"))
+            except ValueError:
+                self._value = 0
             return True
         return False
 

--- a/src/abbfreeathome/devices/room_temperature_controller.py
+++ b/src/abbfreeathome/devices/room_temperature_controller.py
@@ -151,7 +151,7 @@ class RoomTemperatureController(Base):
             try:
                 self._valve = int(output.get("value"))
             except ValueError:
-                self._value = 0
+                self._valve = None
             return True
         return False
 

--- a/tests/test_room_temperature_controller.py
+++ b/tests/test_room_temperature_controller.py
@@ -168,6 +168,12 @@ async def test_refresh_state_from_output(
     )
     assert room_temperature_controller.current_temperature == 22.56
 
+    # Check output that reports an empty string for valve
+    room_temperature_controller._refresh_state_from_output(
+        output={"pairingID": 333, "value": ""}
+    )
+    assert room_temperature_controller.valve == 0
+
     # Check output that affects the valve
     room_temperature_controller._refresh_state_from_output(
         output={"pairingID": 333, "value": "57"}

--- a/tests/test_room_temperature_controller.py
+++ b/tests/test_room_temperature_controller.py
@@ -172,7 +172,7 @@ async def test_refresh_state_from_output(
     room_temperature_controller._refresh_state_from_output(
         output={"pairingID": 333, "value": ""}
     )
-    assert room_temperature_controller.valve == 0
+    assert room_temperature_controller.valve is None
 
     # Check output that affects the valve
     room_temperature_controller._refresh_state_from_output(


### PR DESCRIPTION
I just encountered, that it seems to be possible, that F@H websocket reports an empty string for the valve-setting. This results in an exception and e.g. the HA-integration breaks.

This bugfix adds an additional check and in case of a no-int value, sets the valve to 0.