### PR TITLE
Catch ClientConnectionError exceptions

### DIFF
--- a/src/abbfreeathome/api.py
+++ b/src/abbfreeathome/api.py
@@ -11,6 +11,7 @@ import aiohttp
 import aiohttp.client_exceptions
 
 from .exceptions import (
+    ClientConnectionError,
     ConnectionTimeoutException,
     ForbiddenAuthException,
     InvalidApiResponseException,
@@ -45,6 +46,8 @@ class FreeAtHomeSettings:
                 _response_json = await resp.json()
         except aiohttp.client_exceptions.InvalidUrlClientError as e:
             raise InvalidHostException(self._host) from e
+        except aiohttp.client_exceptions.ClientConnectionError as e:
+            raise ClientConnectionError(self._host) from e
 
         assert _response_status == 200
 
@@ -191,6 +194,8 @@ class FreeAtHomeApi:
                     _response = await resp.text()
         except aiohttp.client_exceptions.InvalidUrlClientError as e:
             raise InvalidHostException(self._host) from e
+        except aiohttp.client_exceptions.ClientConnectionError as e:
+            raise ClientConnectionError(self._host) from e
 
         # Check the status code and raise exception accordingly.
         if _response_status == 401:

--- a/src/abbfreeathome/exceptions.py
+++ b/src/abbfreeathome/exceptions.py
@@ -5,6 +5,15 @@ class FreeAtHomeException(Exception):
     """A base class for Free@Home exceptions."""
 
 
+class ClientConnectionError(FreeAtHomeException):
+    """Raise an exception for client connector error."""
+
+    def __init__(self, url: str) -> None:
+        """Initialze the ClientConnectorError class."""
+        self.message = f"Cannot connect to host {url}"
+        super().__init__(self.message)
+
+
 class ConnectionTimeoutException(FreeAtHomeException):
     """Raise an exception if the connection times out."""
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -8,6 +8,7 @@ import pytest
 
 from src.abbfreeathome.api import FreeAtHomeApi, FreeAtHomeSettings
 from src.abbfreeathome.exceptions import (
+    ClientConnectionError,
     ConnectionTimeoutException,
     ForbiddenAuthException,
     InvalidApiResponseException,
@@ -68,6 +69,15 @@ async def test_get_settings_invalid_host(settings):
         await settings.load()
 
 
+@pytest.mark.asyncio
+async def test_get_settings_client_connection_error(settings):
+    """Test the _request function for an invalid client."""
+    settings._host = "http://0.0.0.0:1"
+
+    with pytest.raises(ClientConnectionError):
+        await settings.load()
+
+
 def test_get_user(settings):
     """Test getting a user."""
     settings._settings = {"users": [{"name": "test_user"}]}
@@ -88,13 +98,13 @@ def test_get_flag(settings):
 
 
 def test_hardware_version_property(settings):
-    """Test getting verison."""
+    """Test getting hardware verison."""
     settings._settings = {"flags": {"hardwareVersion": "54321"}}
     assert settings.hardware_version == "54321"
 
 
 def test_version_property(settings):
-    """Test getting verison."""
+    """Test getting version."""
     settings._settings = {"flags": {"version": "1.0"}}
     assert settings.version == "1.0"
 
@@ -420,6 +430,15 @@ async def test_request_invalid_host(api):
     api._host = "192.168.1.1"
 
     with pytest.raises(InvalidHostException):
+        await api._request("/test")
+
+
+@pytest.mark.asyncio
+async def test_request_client_connection_error(api):
+    """Test the _request function for an invalid client."""
+    api._host = "http://0.0.0.0:1"
+
+    with pytest.raises(ClientConnectionError):
         await api._request("/test")
 
 


### PR DESCRIPTION
Right now if you provide a valid hostname or host ip and it's not available an `aiohttp.client_exceptions.ClientConnectionError` exception will be raised and not handled.

This means in HomeAssistant when attempting to setup the integration it'll provide a generic error message and the exception will be logged.

This PR adds a new FreeAtHome Exception `ClientConnectionError` which can be caught in Home Assistant to provide more valuable feedback to the client.