### PR TITLE
Test for device class by type vs isinstance

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ packages = ["src/abbfreeathome"]
 
 [project]
 name = "local-abbfreeathome"
-version = "1.14.0"
+version = "1.14.1"
 authors = [
   { name="Adam Kingsley", email="adam@kingsley.io" },
 ]

--- a/src/abbfreeathome/dev-requirements.txt
+++ b/src/abbfreeathome/dev-requirements.txt
@@ -1,4 +1,7 @@
-aiohttp==3.10.*
+# There's an issue with aioresponses and the latest version of aiohttp
+# Pin an earlier version for development until PR is merged and released.
+# https://github.com/pnuckowski/aioresponses/pull/262
+aiohttp<3.11.0
 pytest
 pytest-asyncio
 pytest-cov

--- a/src/abbfreeathome/dev-requirements.txt
+++ b/src/abbfreeathome/dev-requirements.txt
@@ -1,4 +1,4 @@
-aiohttp
+aiohttp==3.10.*
 pytest
 pytest-asyncio
 pytest-cov

--- a/src/abbfreeathome/freeathome.py
+++ b/src/abbfreeathome/freeathome.py
@@ -47,7 +47,7 @@ class FreeAtHome:
         return [
             _device
             for _device in self._devices.values()
-            if isinstance(_device, device_class)
+            if type(_device) is device_class
         ]
 
     async def get_devices_by_function(self, function: Function) -> list[dict]:

--- a/tests/test_freeathome.py
+++ b/tests/test_freeathome.py
@@ -319,12 +319,13 @@ async def test_get_room_name(freeathome):
     assert room_name is None
 
 
-def test_get_device_by_class(freeathome):
+@pytest.mark.asyncio
+async def test_get_device_by_class(freeathome):
     """Test the get_device_class function."""
-    device = MagicMock(spec=SwitchActuator)
-    freeathome._devices = {"device1": device}
+    await freeathome.load_devices()
+
     devices = freeathome.get_devices_by_class(SwitchActuator)
-    assert devices == [device]
+    assert len(devices) == 2
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
When testing for device class using isinstance it also pulls in sub-classes.

We want to get the class by the exact type, we don’t want to include type inheritence.