### PR TITLE
Adjust Forced Position for Easier Integration

### DIFF
--- a/src/abbfreeathome/devices/cover_actuator.py
+++ b/src/abbfreeathome/devices/cover_actuator.py
@@ -101,10 +101,10 @@ class CoverActuator(Base):
         if self.state in [2, 3]:
             await self._set_stop_datapoint()
 
-    async def set_forced_position(self, position: str):
+    async def set_forced_position(self, forced_position_name: str):
         """Force the position of the cover."""
         try:
-            _position = CoverActuatorForcedPosition[position]
+            _position = CoverActuatorForcedPosition[forced_position_name]
         except KeyError:
             _position = CoverActuatorForcedPosition.unknown
 

--- a/src/abbfreeathome/devices/dimming_actuator.py
+++ b/src/abbfreeathome/devices/dimming_actuator.py
@@ -97,10 +97,10 @@ class DimmingActuator(Base):
         await self._set_brightness_datapoint(str(value))
         self._brightness = value
 
-    async def set_forced_position(self, position: str):
+    async def set_forced_position(self, forced_position_name: str):
         """Set the forced-option on the dimmer."""
         try:
-            _position = DimmingActuatorForcedPosition[position]
+            _position = DimmingActuatorForcedPosition[forced_position_name]
         except KeyError:
             _position = DimmingActuatorForcedPosition.unknown
 

--- a/src/abbfreeathome/devices/switch_actuator.py
+++ b/src/abbfreeathome/devices/switch_actuator.py
@@ -77,10 +77,10 @@ class SwitchActuator(Base):
         await self._set_switching_datapoint("0")
         self._state = False
 
-    async def set_forced_position(self, position: str):
+    async def set_forced_position(self, forced_position_name: str):
         """Set the forced-option on the switch."""
         try:
-            _position = SwitchActuatorForcedPosition[position]
+            _position = SwitchActuatorForcedPosition[forced_position_name]
         except KeyError:
             _position = SwitchActuatorForcedPosition.unknown
 

--- a/tests/test_cover_actuator.py
+++ b/tests/test_cover_actuator.py
@@ -7,7 +7,7 @@ import pytest
 from src.abbfreeathome.api import FreeAtHomeApi
 from src.abbfreeathome.devices.cover_actuator import (
     CoverActuator,
-    CoverActuatorForcePosition,
+    CoverActuatorForcedPosition,
     ShutterActuator,
 )
 
@@ -166,36 +166,49 @@ async def test_stop(cover_actuator):
 
 
 @pytest.mark.asyncio
-async def test_set_force_position(cover_actuator):
+async def test_set_forced_position(cover_actuator):
     """Test to force a position of a cover."""
-    await cover_actuator.set_force_position(CoverActuatorForcePosition.deactivated)
+    await cover_actuator.set_forced_position(
+        CoverActuatorForcedPosition.deactivated.name
+    )
+    assert (
+        cover_actuator.forced_position == CoverActuatorForcedPosition.deactivated.name
+    )
     cover_actuator._api.set_datapoint.assert_called_with(
         device_id="ABB2AC253651",
         channel_id="ch0003",
         datapoint="idp0004",
         value="0",
     )
-    assert cover_actuator.forced_position == CoverActuatorForcePosition.deactivated.name
 
-    await cover_actuator.set_force_position(CoverActuatorForcePosition.forced_open)
+    await cover_actuator.set_forced_position(
+        CoverActuatorForcedPosition.forced_open.name
+    )
+    assert (
+        cover_actuator.forced_position == CoverActuatorForcedPosition.forced_open.name
+    )
     cover_actuator._api.set_datapoint.assert_called_with(
         device_id="ABB2AC253651",
         channel_id="ch0003",
         datapoint="idp0004",
         value="2",
     )
-    assert cover_actuator.forced_position == CoverActuatorForcePosition.forced_open.name
 
-    await cover_actuator.set_force_position(CoverActuatorForcePosition.forced_close)
+    await cover_actuator.set_forced_position(
+        CoverActuatorForcedPosition.forced_closed.name
+    )
+    assert (
+        cover_actuator.forced_position == CoverActuatorForcedPosition.forced_closed.name
+    )
     cover_actuator._api.set_datapoint.assert_called_with(
         device_id="ABB2AC253651",
         channel_id="ch0003",
         datapoint="idp0004",
         value="3",
     )
-    assert (
-        cover_actuator.forced_position == CoverActuatorForcePosition.forced_close.name
-    )
+
+    await cover_actuator.set_forced_position("INVALID")
+    assert cover_actuator.forced_position == CoverActuatorForcedPosition.unknown.name
 
 
 @pytest.mark.asyncio
@@ -271,10 +284,12 @@ async def test_refresh_state_from_output(cover_actuator):
 
     # Check output that affects the forced position
     cover_actuator._refresh_state_from_output(output={"pairingID": 257, "value": "2"})
-    assert cover_actuator.forced_position == CoverActuatorForcePosition.forced_open.name
+    assert (
+        cover_actuator.forced_position == CoverActuatorForcedPosition.forced_open.name
+    )
 
     cover_actuator._refresh_state_from_output(output={"pairingID": 257, "value": "4"})
-    assert cover_actuator.forced_position == CoverActuatorForcePosition.unknown.name
+    assert cover_actuator.forced_position == CoverActuatorForcedPosition.unknown.name
 
     # Check output that affects the position
     cover_actuator._refresh_state_from_output(output={"pairingID": 289, "value": "35"})

--- a/tests/test_dimming_actuator.py
+++ b/tests/test_dimming_actuator.py
@@ -7,8 +7,7 @@ import pytest
 from src.abbfreeathome.api import FreeAtHomeApi
 from src.abbfreeathome.devices.dimming_actuator import (
     DimmingActuator,
-    DimmingActuatorForceCommand,
-    DimmingActuatorForceState,
+    DimmingActuatorForcedPosition,
 )
 
 
@@ -92,29 +91,48 @@ async def test_set_brightness(dimming_actuator):
 @pytest.mark.asyncio
 async def test_set_forced(dimming_actuator):
     """Test to set the forced option of the DimmingActuator."""
-    await dimming_actuator.set_forced(DimmingActuatorForceCommand.deactivate)
-    assert dimming_actuator.forced == DimmingActuatorForceState.deactivated.name
+    await dimming_actuator.set_forced_position(
+        DimmingActuatorForcedPosition.deactivated.name
+    )
+    assert (
+        dimming_actuator.forced_posiiton
+        == DimmingActuatorForcedPosition.deactivated.name
+    )
     dimming_actuator._api.set_datapoint.assert_called_with(
         device_id="ABB70139AF8A",
         channel_id="ch0000",
         datapoint="idp0004",
         value="0",
     )
-    await dimming_actuator.set_forced(DimmingActuatorForceCommand.force_off)
-    assert dimming_actuator.forced == DimmingActuatorForceState.forced_off.name
+    await dimming_actuator.set_forced_position(
+        DimmingActuatorForcedPosition.forced_off.name
+    )
+    assert (
+        dimming_actuator.forced_posiiton
+        == DimmingActuatorForcedPosition.forced_off.name
+    )
     dimming_actuator._api.set_datapoint.assert_called_with(
         device_id="ABB70139AF8A",
         channel_id="ch0000",
         datapoint="idp0004",
         value="2",
     )
-    await dimming_actuator.set_forced(DimmingActuatorForceCommand.force_on)
-    assert dimming_actuator.forced == DimmingActuatorForceState.forced_on.name
+    await dimming_actuator.set_forced_position(
+        DimmingActuatorForcedPosition.forced_on.name
+    )
+    assert (
+        dimming_actuator.forced_posiiton == DimmingActuatorForcedPosition.forced_on.name
+    )
     dimming_actuator._api.set_datapoint.assert_called_with(
         device_id="ABB70139AF8A",
         channel_id="ch0000",
         datapoint="idp0004",
         value="3",
+    )
+
+    await dimming_actuator.set_forced_position("INVALID")
+    assert (
+        dimming_actuator.forced_posiiton == DimmingActuatorForcedPosition.unknown.name
     )
 
 
@@ -149,10 +167,12 @@ def test_refresh_state_from_output(dimming_actuator):
     dimming_actuator._refresh_state_from_output(
         output={
             "pairingID": 257,
-            "value": str(DimmingActuatorForceState.forced_on.value),
+            "value": DimmingActuatorForcedPosition.forced_on.value,
         },
     )
-    assert dimming_actuator.forced == DimmingActuatorForceState.forced_on.name
+    assert (
+        dimming_actuator.forced_posiiton == DimmingActuatorForcedPosition.forced_on.name
+    )
 
 
 def test_update_device(dimming_actuator):

--- a/tests/test_switch_actuator.py
+++ b/tests/test_switch_actuator.py
@@ -7,8 +7,7 @@ import pytest
 from src.abbfreeathome.api import FreeAtHomeApi
 from src.abbfreeathome.devices.switch_actuator import (
     SwitchActuator,
-    SwitchActuatorForceCommand,
-    SwitchActuatorForceState,
+    SwitchActuatorForcedPosition,
 )
 
 
@@ -82,30 +81,45 @@ async def test_turn_off(switch_actuator):
 @pytest.mark.asyncio
 async def test_set_forced(switch_actuator):
     """Test to set the forced option of the switch."""
-    await switch_actuator.set_forced(SwitchActuatorForceCommand.deactivate)
-    assert switch_actuator.forced == SwitchActuatorForceState.deactivated.name
+    await switch_actuator.set_forced_position(
+        SwitchActuatorForcedPosition.deactivated.name
+    )
+    assert (
+        switch_actuator.forced_position == SwitchActuatorForcedPosition.deactivated.name
+    )
     switch_actuator._api.set_datapoint.assert_called_with(
         device_id="ABB7F500E17A",
         channel_id="ch0003",
         datapoint="idp0002",
         value="0",
     )
-    await switch_actuator.set_forced(SwitchActuatorForceCommand.force_off)
-    assert switch_actuator.forced == SwitchActuatorForceState.forced_off.name
+    await switch_actuator.set_forced_position(
+        SwitchActuatorForcedPosition.forced_off.name
+    )
+    assert (
+        switch_actuator.forced_position == SwitchActuatorForcedPosition.forced_off.name
+    )
     switch_actuator._api.set_datapoint.assert_called_with(
         device_id="ABB7F500E17A",
         channel_id="ch0003",
         datapoint="idp0002",
         value="2",
     )
-    await switch_actuator.set_forced(SwitchActuatorForceCommand.force_on)
-    assert switch_actuator.forced == SwitchActuatorForceState.forced_on.name
+    await switch_actuator.set_forced_position(
+        SwitchActuatorForcedPosition.forced_on.name
+    )
+    assert (
+        switch_actuator.forced_position == SwitchActuatorForcedPosition.forced_on.name
+    )
     switch_actuator._api.set_datapoint.assert_called_with(
         device_id="ABB7F500E17A",
         channel_id="ch0003",
         datapoint="idp0002",
         value="3",
     )
+
+    await switch_actuator.set_forced_position("INVALID")
+    assert switch_actuator.forced_position == SwitchActuatorForcedPosition.unknown.name
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Closes #114 

This will make integrating with home assistant easier and reduce the amount of code required to implement.

- Use a single enum for force positions.
- Adjust set_force_position to take the output/state and convert it to the input value (command)
- Add the term position e.g. `forced_position` to better describe what is being done.
