### PR TITLE
Bump Version, Add Pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,10 @@
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    # Ruff version.
+    rev: v0.7.3
+    hooks:
+      # Run the linter.
+      - id: ruff
+        args: [--fix]
+      # Run the formatter.
+      - id: ruff-format

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ packages = ["src/abbfreeathome"]
 
 [project]
 name = "local-abbfreeathome"
-version = "1.14.1"
+version = "1.15.0"
 authors = [
   { name="Adam Kingsley", email="adam@kingsley.io" },
 ]

--- a/src/abbfreeathome/dev-requirements.txt
+++ b/src/abbfreeathome/dev-requirements.txt
@@ -1,8 +1,7 @@
-# There's an issue with aioresponses and the latest version of aiohttp
-# Pin an earlier version for development until PR is merged and released.
-# https://github.com/pnuckowski/aioresponses/pull/262
-aiohttp<3.11.0
+aiohttp!=3.11.0
 pytest
 pytest-asyncio
 pytest-cov
 aioresponses
+ruff
+pre-commit


### PR DESCRIPTION
This adds pre-commit to the repo to ensure checks are easily performed locally before committing. Right now this just includes the ruff linter and formatter.

The `aiohttp` package has pushed a backwards compatible version, I've adjust the dev-requirements to ensure we don't use the non-backwards compatible version.