### PR TITLE
Log all websocket responses to debug

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ packages = ["src/abbfreeathome"]
 
 [project]
 name = "local-abbfreeathome"
-version = "1.16.1"
+version = "1.16.2"
 authors = [
   { name="Adam Kingsley", email="adam@kingsley.io" },
 ]

--- a/src/abbfreeathome/api.py
+++ b/src/abbfreeathome/api.py
@@ -318,6 +318,8 @@ class FreeAtHomeApi:
         data = await self._ws_response.receive()
         if data.type == WSMsgType.TEXT:
             _ws_data = data.json().get(self._sysap_uuid)
+
+            _LOGGER.debug("Websocket Response: %s", _ws_data)
             if callback and inspect.iscoroutinefunction(callback):
                 await callback(_ws_data)
             elif callback:


### PR DESCRIPTION
This is a simple PR to log all web socket responses to debug.

This can be useful, especially when attempting to implement new devices to know what data is posted to the web socket from the device.

You would still need to know the configuration from the api, but could be quite useful in Home Assistant which allows you to filter the logs (e.g. you can filter the logs by a specific serial `ABB7F62F6C0B` to view all events).

#### Example Output

```
DEBUG:abbfreeathome.api:Websocket Response: {'datapoints': {'ABB7F62F6C0B/ch0003/idp0000': '1'}, 'parameters': {}, 'devices': {}, 'devicesAdded': [], 'devicesRemoved': [], 'scenesTriggered': {}}
DEBUG:abbfreeathome.api:Websocket Response: {'datapoints': {'ABB7F62F6C0B/ch0000/idp0000': '1', 'ABB7F62F6C0B/ch0003/odp0000': '1'}, 'parameters': {}, 'devices': {}, 'devicesAdded': [], 'devicesRemoved': [], 'scenesTriggered': {}}
```