### PR TITLE
Implement virtual device support

### DIFF
--- a/src/abbfreeathome/bin/interface.py
+++ b/src/abbfreeathome/bin/interface.py
@@ -16,4 +16,3 @@ class Interface(enum.Enum):
     WIRELESS_RF = "RF"
     HUE = "hue"
     SONOS = "sonos"
-    VIRTUAL_DEVICE = "vdev:installer@busch-jaeger.de"

--- a/src/abbfreeathome/const.py
+++ b/src/abbfreeathome/const.py
@@ -21,11 +21,18 @@ from .devices.rain_sensor import RainSensor
 from .devices.room_temperature_controller import RoomTemperatureController
 from .devices.smoke_detector import SmokeDetector
 from .devices.switch_actuator import SwitchActuator
+from .devices.switch_actuator_virtual import SwitchActuatorVirtual
 from .devices.switch_sensor import DimmingSensor, SwitchSensor
 from .devices.temperature_sensor import TemperatureSensor
 from .devices.trigger import Trigger
 from .devices.wind_sensor import WindSensor
 from .devices.window_door_sensor import WindowDoorSensor
+from .devices.window_door_sensor_virtual import WindowDoorSensorVirtual
+
+FUNCTION_DEVICE_MAPPING_VIRTUAL: dict[Function, Base] = {
+    Function.FID_WINDOW_DOOR_SENSOR: WindowDoorSensorVirtual,
+    Function.FID_SWITCH_ACTUATOR: SwitchActuatorVirtual,
+}
 
 FUNCTION_DEVICE_MAPPING: dict[Function, Base] = {
     Function.FID_ATTIC_WINDOW_ACTUATOR: AtticWindowActuator,

--- a/src/abbfreeathome/devices/switch_actuator_virtual.py
+++ b/src/abbfreeathome/devices/switch_actuator_virtual.py
@@ -1,0 +1,82 @@
+"""Free@Home SwitchActuatorVirtual Class."""
+
+from typing import Any
+
+from ..api import FreeAtHomeApi
+from ..bin.pairing import Pairing
+from .base import Base
+
+
+class SwitchActuatorVirtual(Base):
+    """Free@Home SwitchActuatorVirtual Class."""
+
+    _state_refresh_input_pairings: list[Pairing] = [
+        Pairing.AL_SWITCH_ON_OFF,
+    ]
+
+    def __init__(
+        self,
+        device_id: str,
+        device_name: str,
+        channel_id: str,
+        channel_name: str,
+        inputs: dict[str, dict[str, Any]],
+        outputs: dict[str, dict[str, Any]],
+        parameters: dict[str, dict[str, Any]],
+        api: FreeAtHomeApi,
+        floor_name: str | None = None,
+        room_name: str | None = None,
+    ) -> None:
+        """Initialize the Free@Home SwitchActuatorVirtual class."""
+        self._state: bool | None = None
+
+        super().__init__(
+            device_id,
+            device_name,
+            channel_id,
+            channel_name,
+            inputs,
+            outputs,
+            parameters,
+            api,
+            floor_name,
+            room_name,
+        )
+
+    @property
+    def state(self) -> bool | None:
+        """Get the state of the switch."""
+        return self._state
+
+    async def turn_on(self):
+        """Turn on the switch."""
+        await self._set_switching_datapoint("1")
+        self._state = True
+
+    async def turn_off(self):
+        """Turn on the switch."""
+        await self._set_switching_datapoint("0")
+        self._state = False
+
+    def _refresh_state_from_input(self, input: dict[str, Any]) -> bool:
+        """
+        Refresh the state of the device from a given input.
+
+        This will return whether the state was refreshed as a boolean value.
+        """
+        if input.get("pairingID") == Pairing.AL_SWITCH_ON_OFF.value:
+            self._state = input.get("value") == "1"
+            return True
+        return False
+
+    async def _set_switching_datapoint(self, value: str):
+        """Set the switching datapoint on the api."""
+        _output_id, _output_value = self.get_output_by_pairing(
+            pairing=Pairing.AL_INFO_ON_OFF
+        )
+        return await self._api.set_datapoint(
+            device_id=self.device_id,
+            channel_id=self.channel_id,
+            datapoint=_output_id,
+            value=value,
+        )

--- a/src/abbfreeathome/devices/window_door_sensor_virtual.py
+++ b/src/abbfreeathome/devices/window_door_sensor_virtual.py
@@ -1,0 +1,67 @@
+"""Free@Home WindowDoorSensorVirtual Class."""
+
+from typing import Any
+
+from ..api import FreeAtHomeApi
+from ..bin.pairing import Pairing
+from .base import Base
+
+
+class WindowDoorSensorVirtual(Base):
+    """Free@Home WindowDoorSensorVirtual Class."""
+
+    def __init__(
+        self,
+        device_id: str,
+        device_name: str,
+        channel_id: str,
+        channel_name: str,
+        inputs: dict[str, dict[str, Any]],
+        outputs: dict[str, dict[str, Any]],
+        parameters: dict[str, dict[str, Any]],
+        api: FreeAtHomeApi,
+        floor_name: str | None = None,
+        room_name: str | None = None,
+    ) -> None:
+        """Initialize the Free@Home WindowDoorSensorVirtual class."""
+        self._state: bool | None = None
+
+        super().__init__(
+            device_id,
+            device_name,
+            channel_id,
+            channel_name,
+            inputs,
+            outputs,
+            parameters,
+            api,
+            floor_name,
+            room_name,
+        )
+
+    @property
+    def state(self) -> bool | None:
+        """Get the sensor state."""
+        return self._state
+
+    async def open(self):
+        """Open the sensor."""
+        await self._set_switching_datapoint("1")
+        self._state = True
+
+    async def close(self):
+        """Close the sensor."""
+        await self._set_switching_datapoint("0")
+        self._state = False
+
+    async def _set_switching_datapoint(self, value: str):
+        """Set the sensor datapoint on the api."""
+        _output_id, _output_value = self.get_output_by_pairing(
+            pairing=Pairing.AL_WINDOW_DOOR
+        )
+        return await self._api.set_datapoint(
+            device_id=self.device_id,
+            channel_id=self.channel_id,
+            datapoint=_output_id,
+            value=value,
+        )


### PR DESCRIPTION
This is the first try to implement virtual device support. No tests are written yet as I first want to have consensus about my approach.

I re-implemented everything what I removed in #103 and created dedicated ...Virtual classes.

For now I only implemented a "WindowDoorSensor" and a "SwitchActuator".

As the return of the F@H-API regarding virtual devices `interface=vdev:...` seems to be unreliable I moved to a check of the device_id: All my tests showed that a virtual device device_id always starts with `6000`