### PR TITLE
Limit api usage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ packages = ["src/abbfreeathome"]
 
 [project]
 name = "local-abbfreeathome"
-version = "1.17.4"
+version = "1.18.0"
 authors = [
   { name="Adam Kingsley", email="adam@kingsley.io" },
 ]

--- a/src/abbfreeathome/devices/dimming_actuator.py
+++ b/src/abbfreeathome/devices/dimming_actuator.py
@@ -76,13 +76,15 @@ class DimmingActuator(Base):
 
     async def turn_on(self):
         """Turn on the dimmer."""
-        await self._set_switching_datapoint("1")
-        self._state = True
+        if not self._state:
+            await self._set_switching_datapoint("1")
+            self._state = True
 
     async def turn_off(self):
         """Turn on the dimmer."""
-        await self._set_switching_datapoint("0")
-        self._state = False
+        if self._state:
+            await self._set_switching_datapoint("0")
+            self._state = False
 
     async def set_brightness(self, value: int):
         """

--- a/src/abbfreeathome/devices/switch_actuator.py
+++ b/src/abbfreeathome/devices/switch_actuator.py
@@ -69,13 +69,15 @@ class SwitchActuator(Base):
 
     async def turn_on(self):
         """Turn on the switch."""
-        await self._set_switching_datapoint("1")
-        self._state = True
+        if not self._state:
+            await self._set_switching_datapoint("1")
+            self._state = True
 
     async def turn_off(self):
         """Turn on the switch."""
-        await self._set_switching_datapoint("0")
-        self._state = False
+        if self._state:
+            await self._set_switching_datapoint("0")
+            self._state = False
 
     async def set_forced_position(self, forced_position_name: str):
         """Set the forced-option on the switch."""

--- a/tests/test_dimming_actuator.py
+++ b/tests/test_dimming_actuator.py
@@ -52,8 +52,10 @@ async def test_initial_state(dimming_actuator):
 
 
 @pytest.mark.asyncio
-async def test_turn_on(dimming_actuator):
+async def test_turn_on_while_off(dimming_actuator):
     """Test to turning on the DimmingActuator."""
+    dimming_actuator._state = False
+    assert dimming_actuator.state is False
     await dimming_actuator.turn_on()
     assert dimming_actuator.state is True
     dimming_actuator._api.set_datapoint.assert_called_with(
@@ -65,8 +67,20 @@ async def test_turn_on(dimming_actuator):
 
 
 @pytest.mark.asyncio
-async def test_turn_off(dimming_actuator):
+async def test_turn_on_while_on(dimming_actuator):
+    """Test to turning on the DimmingActuator, while already on."""
+    dimming_actuator._state = True
+    assert dimming_actuator.state is True
+    await dimming_actuator.turn_on()
+    assert dimming_actuator.state is True
+    dimming_actuator._api.set_datapoint.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_turn_off_while_on(dimming_actuator):
     """Test to turning off the DimmingActuator."""
+    dimming_actuator._state = True
+    assert dimming_actuator.state is True
     await dimming_actuator.turn_off()
     assert dimming_actuator.state is False
     dimming_actuator._api.set_datapoint.assert_called_with(
@@ -75,6 +89,16 @@ async def test_turn_off(dimming_actuator):
         datapoint="idp0000",
         value="0",
     )
+
+
+@pytest.mark.asyncio
+async def test_turn_off_while_off(dimming_actuator):
+    """Test to turning off the DimmingActuator, while already off."""
+    dimming_actuator._state = False
+    assert dimming_actuator.state is False
+    await dimming_actuator.turn_off()
+    assert dimming_actuator.state is False
+    dimming_actuator._api.set_datapoint.assert_not_called()
 
 
 @pytest.mark.asyncio

--- a/tests/test_switch_actuator.py
+++ b/tests/test_switch_actuator.py
@@ -53,8 +53,10 @@ async def test_initial_state(switch_actuator):
 
 
 @pytest.mark.asyncio
-async def test_turn_on(switch_actuator):
+async def test_turn_on_while_off(switch_actuator):
     """Test to turning on of the switch."""
+    switch_actuator._state = False
+    assert switch_actuator.state is False
     await switch_actuator.turn_on()
     assert switch_actuator.state is True
     switch_actuator._api.set_datapoint.assert_called_with(
@@ -66,8 +68,20 @@ async def test_turn_on(switch_actuator):
 
 
 @pytest.mark.asyncio
-async def test_turn_off(switch_actuator):
+async def test_turn_on_while_on(switch_actuator):
+    """Test to turning on of the switch, while already on."""
+    switch_actuator._state = True
+    assert switch_actuator.state is True
+    await switch_actuator.turn_on()
+    assert switch_actuator.state is True
+    switch_actuator._api.set_datapoint.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_turn_off_while_on(switch_actuator):
     """Test to turning off of the switch."""
+    switch_actuator._state = True
+    assert switch_actuator.state is True
     await switch_actuator.turn_off()
     assert switch_actuator.state is False
     switch_actuator._api.set_datapoint.assert_called_with(
@@ -76,6 +90,16 @@ async def test_turn_off(switch_actuator):
         datapoint="idp0000",
         value="0",
     )
+
+
+@pytest.mark.asyncio
+async def test_turn_off_while_off(switch_actuator):
+    """Test to turning off of the switch, while already off."""
+    switch_actuator._state = False
+    assert switch_actuator.state is False
+    await switch_actuator.turn_off()
+    assert switch_actuator.state is False
+    switch_actuator._api.set_datapoint.assert_not_called()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
If the state of a dimming_actuator or switch_actuator is already in the desired state (e.g. execute turn_off() and device is already turned off) no call is placed on the API.

Closes #144 