### PR TITLE
Covert strings to float before int

### DIFF
--- a/src/abbfreeathome/devices/cover_actuator.py
+++ b/src/abbfreeathome/devices/cover_actuator.py
@@ -152,13 +152,13 @@ class CoverActuator(Base):
             output.get("pairingID")
             == Pairing.AL_CURRENT_ABSOLUTE_POSITION_BLINDS_PERCENTAGE.value
         ):
-            self._position = int(output.get("value"))
+            self._position = int(float(output.get("value")))
             return True
         if (
             output.get("pairingID")
             == Pairing.AL_CURRENT_ABSOLUTE_POSITION_SLATS_PERCENTAGE.value
         ):
-            self._tilt_position = int(output.get("value"))
+            self._tilt_position = int(float(output.get("value")))
             return True
         return False
 

--- a/src/abbfreeathome/devices/dimming_actuator.py
+++ b/src/abbfreeathome/devices/dimming_actuator.py
@@ -123,7 +123,7 @@ class DimmingActuator(Base):
             self._state = output.get("value") == "1"
             return True
         if output.get("pairingID") == Pairing.AL_INFO_ACTUAL_DIMMING_VALUE.value:
-            self._brightness = output.get("value")
+            self._brightness = int(float(output.get("value")))
             return True
         if output.get("pairingID") == Pairing.AL_INFO_FORCE.value:
             try:

--- a/src/abbfreeathome/devices/heating_actuator.py
+++ b/src/abbfreeathome/devices/heating_actuator.py
@@ -69,7 +69,7 @@ class HeatingActuator(Base):
         This will return whether the state was refreshed as a boolean value.
         """
         if output.get("pairingID") == Pairing.AL_INFO_VALUE_HEATING.value:
-            self._position = int(output.get("value"))
+            self._position = int(float(output.get("value")))
             return True
         return False
 

--- a/src/abbfreeathome/devices/room_temperature_controller.py
+++ b/src/abbfreeathome/devices/room_temperature_controller.py
@@ -149,7 +149,7 @@ class RoomTemperatureController(Base):
             return True
         if output.get("pairingID") == Pairing.AL_HEATING_DEMAND.value:
             try:
-                self._valve = int(output.get("value"))
+                self._valve = int(float(output.get("value")))
             except ValueError:
                 self._valve = None
             return True

--- a/tests/test_cover_actuator.py
+++ b/tests/test_cover_actuator.py
@@ -271,12 +271,22 @@ async def test_refresh_state_from_output(cover_actuator):
     cover_actuator._refresh_state_from_output(output={"pairingID": 289, "value": "35"})
     assert cover_actuator.position == 35
 
+    # Check output that affects the position with a float value
+    cover_actuator._refresh_state_from_output(
+        output={"pairingID": 289, "value": "2.35294"}
+    )
+    assert cover_actuator.position == 2
+
     # Check output that affects the tilt
     cover_actuator._refresh_state_from_output(output={"pairingID": 290, "value": "45"})
     assert cover_actuator._tilt_position == 45
+
+    # Check output that affects the tile with a float value
+    cover_actuator._refresh_state_from_output(output={"pairingID": 290, "value": "4.9"})
+    assert cover_actuator._tilt_position == 4
 
     # Check output that does NOT affects the RTC
     cover_actuator._refresh_state_from_output(
         output={"pairingID": 0, "value": "1"},
     )
-    assert cover_actuator.position == 35
+    assert cover_actuator.position == 2

--- a/tests/test_dimming_actuator.py
+++ b/tests/test_dimming_actuator.py
@@ -159,9 +159,15 @@ def test_refresh_state_from_output(dimming_actuator):
 
     # Check output that affects the brightness
     dimming_actuator._refresh_state_from_output(
-        output={"pairingID": 272, "value": 75},
+        output={"pairingID": 272, "value": "75"},
     )
     assert dimming_actuator.brightness == 75
+
+    # Check output that affects the brightness with a float value
+    dimming_actuator._refresh_state_from_output(
+        output={"pairingID": 272, "value": "7.5"}
+    )
+    assert dimming_actuator.brightness == 7
 
     # Check output that affects the force-option
     dimming_actuator._refresh_state_from_output(

--- a/tests/test_heating_actuator.py
+++ b/tests/test_heating_actuator.py
@@ -84,8 +84,14 @@ async def test_refresh_state_from_output(heating_actuator):
     )
     assert heating_actuator.position == 35
 
+    # Check output that affects the position with a float value
+    heating_actuator._refresh_state_from_output(
+        output={"pairingID": 305, "value": "3.5"}
+    )
+    assert heating_actuator.position == 3
+
     # Check output that does NOT affects the position
     heating_actuator._refresh_state_from_output(
         output={"pairingID": 273, "value": "1"},
     )
-    assert heating_actuator.position == 35
+    assert heating_actuator.position == 3

--- a/tests/test_room_temperature_controller.py
+++ b/tests/test_room_temperature_controller.py
@@ -180,6 +180,12 @@ async def test_refresh_state_from_output(
     )
     assert room_temperature_controller.valve == 57
 
+    # Check output that affects the valve with a float value
+    room_temperature_controller._refresh_state_from_output(
+        output={"pairingID": 333, "value": "5.7"}
+    )
+    assert room_temperature_controller.valve == 5
+
     # Check output that does NOT affects the RTC
     room_temperature_controller._refresh_state_from_output(
         output={"pairingID": 0, "value": "1"},
@@ -189,7 +195,7 @@ async def test_refresh_state_from_output(
     assert room_temperature_controller.eco_mode is True
     assert room_temperature_controller.state_indication == 68
     assert room_temperature_controller.current_temperature == 22.56
-    assert room_temperature_controller.valve == 57
+    assert room_temperature_controller.valve == 5
 
 
 def test_update_device(room_temperature_controller):


### PR DESCRIPTION
There might be circumstances that returned strings from the F@H api are float and not int.

This PR first converts returned values, which are "ranges" from string to float and than to in.

closes #147 