### PR TITLE
Implement retry logic on FreeAtHome _request method

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 dependencies = [
-  "aiohttp", "packaging"
+  "aiohttp", "packaging", "backoff"
 ]
 
 [project.urls]
@@ -163,6 +163,9 @@ asyncio_default_fixture_loop_scope = "function"
 pythonpath = [
   "."
 ]
+
+[tool.pytest_env]
+FREEATHOME_MAX_REQUEST_TRIES = "1"
 
 [tool.coverage.run]
 omit = ["*/tests/*"]

--- a/src/abbfreeathome/api.py
+++ b/src/abbfreeathome/api.py
@@ -33,6 +33,9 @@ from .exceptions import (
 
 API_VERSION = "v1"
 
+# API Requests Configuration
+DEFAULT_FREEATHOME_MAX_REQUEST_TRIES = 5
+
 _LOGGER = logging.getLogger(__name__)
 
 
@@ -228,7 +231,11 @@ class FreeAtHomeApi:
     @backoff.on_exception(
         backoff.expo,
         InvalidApiResponseException,
-        max_tries=int(os.environ.get("FREEATHOME_MAX_REQUEST_TRIES", 5)),
+        max_tries=int(
+            os.environ.get(
+                "FREEATHOME_MAX_REQUEST_TRIES", DEFAULT_FREEATHOME_MAX_REQUEST_TRIES
+            )
+        ),
     )
     async def _request(self, path: str, method: str = "get", data: Any | None = None):
         """Make a request to the API."""

--- a/src/abbfreeathome/dev-requirements.txt
+++ b/src/abbfreeathome/dev-requirements.txt
@@ -1,8 +1,10 @@
 aiohttp!=3.11.0
 aioresponses
+backoff
 packaging
 pre-commit
 pytest
 pytest-asyncio
 pytest-cov
+pytest-env
 ruff


### PR DESCRIPTION
Closes #149 

This implements a retry with exponential back-off using the [backoff](https://pypi.org/project/backoff/) PyPi package.

When running unit tests, if `InvalidApiResponseException` is raised it attempts to retry, but on the retry it loses the mock-up api response. Because of this, for testing I'm implementing an environment variable `FREEATHOME_MAX_REQUEST_TRIES` that can be set that'll set the number of retries to 1.

By default it'll retry 5 times before throwing an exception, but can be configured at run-time by environment variable `FREEATHOME_MAX_REQUEST_TRIES`.