### PR TITLE
Virtual device support

### DIFF
--- a/src/abbfreeathome/const.py
+++ b/src/abbfreeathome/const.py
@@ -24,6 +24,7 @@ from .devices.switch_actuator import SwitchActuator
 from .devices.switch_sensor import DimmingSensor, SwitchSensor
 from .devices.temperature_sensor import TemperatureSensor
 from .devices.trigger import Trigger
+from .devices.virtual.virtual_switch_actuator import VirtualSwitchActuator
 from .devices.virtual.virtual_window_door_sensor import VirtualWindowDoorSensor
 from .devices.wind_sensor import WindSensor
 from .devices.window_door_sensor import WindowDoorSensor
@@ -77,7 +78,7 @@ FUNCTION_DEVICE_MAPPING: dict[Function, Base] = {
     ),
     Function.FID_SHUTTER_ACTUATOR: ShutterActuator,
     Function.FID_SMOKE_DETECTOR: SmokeDetector,
-    Function.FID_SWITCH_ACTUATOR: SwitchActuator,
+    Function.FID_SWITCH_ACTUATOR: [SwitchActuator, VirtualSwitchActuator],
     Function.FID_E_CONTACT_SWITCH_ACTUATOR_TYPE0: SwitchActuator,
     Function.FID_E_CONTACT_SWITCH_ACTUATOR_TYPE1: SwitchActuator,
     Function.FID_E_CONTACT_SWITCH_ACTUATOR_TYPE2: SwitchActuator,

--- a/src/abbfreeathome/const.py
+++ b/src/abbfreeathome/const.py
@@ -24,6 +24,7 @@ from .devices.switch_actuator import SwitchActuator
 from .devices.switch_sensor import DimmingSensor, SwitchSensor
 from .devices.temperature_sensor import TemperatureSensor
 from .devices.trigger import Trigger
+from .devices.virtual.virtual_window_door_sensor import VirtualWindowDoorSensor
 from .devices.wind_sensor import WindSensor
 from .devices.window_door_sensor import WindowDoorSensor
 
@@ -93,5 +94,5 @@ FUNCTION_DEVICE_MAPPING: dict[Function, Base] = {
     Function.FID_TRIGGER: Trigger,
     Function.FID_WIND_SENSOR: WindSensor,
     Function.FID_WINDOW_DOOR_POSITION_SENSOR: WindowDoorSensor,
-    Function.FID_WINDOW_DOOR_SENSOR: WindowDoorSensor,
+    Function.FID_WINDOW_DOOR_SENSOR: [WindowDoorSensor, VirtualWindowDoorSensor],
 }

--- a/src/abbfreeathome/devices/virtual/virtual_base.py
+++ b/src/abbfreeathome/devices/virtual/virtual_base.py
@@ -1,0 +1,87 @@
+"""Free@Home Base Class for virtual devices."""
+
+import logging
+from typing import Any
+
+from ...api import FreeAtHomeApi
+from ..base import Base
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class VirtualBase(Base):
+    """Free@Home Base Class for virtual devices."""
+
+    def __init__(
+        self,
+        device_id: str,
+        device_name: str,
+        channel_id: str,
+        channel_name: str,
+        inputs: dict[str, dict[str, Any]],
+        outputs: dict[str, dict[str, Any]],
+        parameters: dict[str, dict[str, Any]],
+        api: FreeAtHomeApi,
+        floor_name: str | None = None,
+        room_name: str | None = None,
+    ) -> None:
+        """Initialize the Free@Home VirtualBase class."""
+
+        super().__init__(
+            device_id,
+            device_name,
+            channel_id,
+            channel_name,
+            inputs,
+            outputs,
+            parameters,
+            api,
+            floor_name,
+            room_name,
+        )
+
+    def update_device(self, datapoint_key: str, datapoint_value: str):
+        """Update the device state."""
+        _LOGGER.info(
+            "%s received updated data: %s: %s",
+            self.channel_name,
+            datapoint_key,
+            datapoint_value,
+        )
+        _refreshed = None
+        _io_key = datapoint_key.split("/")[-1]
+
+        if _io_key in self._inputs:
+            self._inputs[_io_key]["value"] = datapoint_value
+            _refreshed = self._refresh_state_from_datapoint(
+                datapoint=self._inputs[_io_key]
+            )
+
+        if _refreshed and self._callbacks:
+            for callback in self._callbacks:
+                callback()
+
+    async def refresh_state(self):
+        """Refresh the state of the device from the api."""
+        for _pairing in self._state_refresh_pairings:
+            _datapoint_id, _datapoint_value = self.get_input_by_pairing(
+                pairing=_pairing
+            )
+            _datapoint = (
+                await self._api.get_datapoint(
+                    device_id=self.device_id,
+                    channel_id=self.channel_id,
+                    datapoint=_datapoint_id,
+                )
+            )[0]
+            self._refresh_state_from_datapoint(
+                datapoint={
+                    "pairingID": _pairing.value,
+                    "value": _datapoint,
+                }
+            )
+
+    def _refresh_state_from_datapoints(self):
+        """Refresh the state of the device from the datapoints."""
+        for _datapoint in self._inputs.values():
+            self._refresh_state_from_datapoint(_datapoint)

--- a/src/abbfreeathome/devices/virtual/virtual_switch_actuator.py
+++ b/src/abbfreeathome/devices/virtual/virtual_switch_actuator.py
@@ -13,8 +13,8 @@ class VirtualSwitchActuatorForcedPosition(enum.Enum):
 
     unknown = None
     deactivated = "0"
-    forced_on = "4"
-    forced_off = "5"
+    forced_on = "3"
+    forced_off = "2"
 
 
 class VirtualSwitchActuator(VirtualBase):
@@ -87,9 +87,9 @@ class VirtualSwitchActuator(VirtualBase):
         if _position == VirtualSwitchActuatorForcedPosition.deactivated:
             await self._set_force_datapoint("0")
         elif _position == VirtualSwitchActuatorForcedPosition.forced_on:
-            await self._set_force_datapoint("3")
+            await self._set_force_datapoint("4")
         elif _position == VirtualSwitchActuatorForcedPosition.forced_off:
-            await self._set_force_datapoint("2")
+            await self._set_force_datapoint("5")
 
         self._forced_position = _position
 

--- a/src/abbfreeathome/devices/virtual/virtual_switch_actuator.py
+++ b/src/abbfreeathome/devices/virtual/virtual_switch_actuator.py
@@ -67,12 +67,12 @@ class VirtualSwitchActuator(VirtualBase):
         """Get the forced state of the switch."""
         return self._forced_position.name
 
-    async def set_on(self):
+    async def turn_on(self):
         """Turn on the switch."""
         await self._set_switching_datapoint("1")
         self._state = True
 
-    async def set_off(self):
+    async def turn_off(self):
         """Turn off the switch."""
         await self._set_switching_datapoint("0")
         self._state = False

--- a/src/abbfreeathome/devices/virtual/virtual_switch_actuator.py
+++ b/src/abbfreeathome/devices/virtual/virtual_switch_actuator.py
@@ -1,0 +1,137 @@
+"""Free@Home Virtual SwitchActuator class."""
+
+import enum
+from typing import Any
+
+from ...api import FreeAtHomeApi
+from ...bin.pairing import Pairing
+from .virtual_base import VirtualBase
+
+
+class VirtualSwitchActuatorForcedPosition(enum.Enum):
+    """An Enum class for the force states."""
+
+    unknown = None
+    deactivated = "0"
+    forced_on = "4"
+    forced_off = "5"
+
+
+class VirtualSwitchActuator(VirtualBase):
+    """Free@Home Virtual SwitchActuator Class."""
+
+    _state_refresh_pairings: list[Pairing] = [
+        Pairing.AL_SWITCH_ON_OFF,
+        Pairing.AL_FORCED,
+    ]
+
+    def __init__(
+        self,
+        device_id: str,
+        device_name: str,
+        channel_id: str,
+        channel_name: str,
+        inputs: dict[str, dict[str, Any]],
+        outputs: dict[str, dict[str, Any]],
+        parameters: dict[str, dict[str, Any]],
+        api: FreeAtHomeApi,
+        floor_name: str | None = None,
+        room_name: str | None = None,
+    ):
+        """Initialize the Free@Home Virtual SwitchActuator class."""
+        self._state: bool | None = None
+        self._forced_position: VirtualSwitchActuatorForcedPosition = (
+            VirtualSwitchActuatorForcedPosition.unknown
+        )
+
+        super().__init__(
+            device_id,
+            device_name,
+            channel_id,
+            channel_name,
+            inputs,
+            outputs,
+            parameters,
+            api,
+            floor_name,
+            room_name,
+        )
+
+    @property
+    def state(self) -> bool | None:
+        """Get the state of the switch."""
+        return self._state
+
+    @property
+    def forced_position(self) -> str | None:
+        """Get the forced state of the switch."""
+        return self._forced_position.name
+
+    async def set_on(self):
+        """Turn on the switch."""
+        await self._set_switching_datapoint("1")
+        self._state = True
+
+    async def set_off(self):
+        """Turn off the switch."""
+        await self._set_switching_datapoint("0")
+        self._state = False
+
+    async def set_forced_position(self, forced_position_name: str):
+        """Set the forced-option on the switch."""
+        try:
+            _position = VirtualSwitchActuatorForcedPosition[forced_position_name]
+        except KeyError:
+            _position = VirtualSwitchActuatorForcedPosition.unknown
+
+        if _position == VirtualSwitchActuatorForcedPosition.deactivated:
+            await self._set_force_datapoint("0")
+        elif _position == VirtualSwitchActuatorForcedPosition.forced_on:
+            await self._set_force_datapoint("3")
+        elif _position == VirtualSwitchActuatorForcedPosition.forced_off:
+            await self._set_force_datapoint("2")
+
+        self._forced_position = _position
+
+    def _refresh_state_from_datapoint(self, datapoint: dict[str, Any]) -> bool:
+        """
+        Refresh the state of the device from a given input.
+
+        This will return whether the state was refreshed as a boolean value.
+        """
+        if datapoint.get("pairingID") == Pairing.AL_SWITCH_ON_OFF.value:
+            self._state = datapoint.get("value") == "1"
+            return True
+        if datapoint.get("pairingID") == Pairing.AL_FORCED.value:
+            try:
+                self._forced_position = VirtualSwitchActuatorForcedPosition(
+                    datapoint.get("value")
+                )
+            except ValueError:
+                self._forced_position = VirtualSwitchActuatorForcedPosition.unknown
+            return True
+        return False
+
+    async def _set_switching_datapoint(self, value: str):
+        """Set the switching datapoint on the api."""
+        _switch_output_id, _switch_output_value = self.get_output_by_pairing(
+            pairing=Pairing.AL_INFO_ON_OFF
+        )
+        return await self._api.set_datapoint(
+            device_id=self.device_id,
+            channel_id=self.channel_id,
+            datapoint=_switch_output_id,
+            value=value,
+        )
+
+    async def _set_force_datapoint(self, value: str):
+        """Set the force datapoint on the api."""
+        _force_output_id, _force_output_value = self.get_output_by_pairing(
+            pairing=Pairing.AL_INFO_FORCE
+        )
+        return await self._api.set_datapoint(
+            device_id=self.device_id,
+            channel_id=self.channel_id,
+            datapoint=_force_output_id,
+            value=value,
+        )

--- a/src/abbfreeathome/devices/virtual/virtual_window_door_sensor.py
+++ b/src/abbfreeathome/devices/virtual/virtual_window_door_sensor.py
@@ -1,0 +1,67 @@
+"""Free@Home Virtual WindowDoorSensor Class."""
+
+from typing import Any
+
+from ...api import FreeAtHomeApi
+from ...bin.pairing import Pairing
+from .virtual_base import VirtualBase
+
+
+class VirtualWindowDoorSensor(VirtualBase):
+    """Free@Home Virtual WindowDoorSensor Class."""
+
+    def __init__(
+        self,
+        device_id: str,
+        device_name: str,
+        channel_id: str,
+        channel_name: str,
+        inputs: dict[str, dict[str, Any]],
+        outputs: dict[str, dict[str, Any]],
+        parameters: dict[str, dict[str, Any]],
+        api: FreeAtHomeApi,
+        floor_name: str | None = None,
+        room_name: str | None = None,
+    ):
+        """Initialize the Free@Home Virtual WindowDoorSensor class."""
+        self._state: bool | None = None
+
+        super().__init__(
+            device_id,
+            device_name,
+            channel_id,
+            channel_name,
+            inputs,
+            outputs,
+            parameters,
+            api,
+            floor_name,
+            room_name,
+        )
+
+    @property
+    def state(self) -> bool | None:
+        """Get the sensor state."""
+        return self._state
+
+    async def set_on(self):
+        """Activate the sensor."""
+        await self._set_sensor_datapoint("1")
+        self._state = True
+
+    async def set_off(self):
+        """Deactivate the sensor."""
+        await self._set_sensor_datapoint("0")
+        self._state = False
+
+    async def _set_sensor_datapoint(self, value: str):
+        """Set the sensor datapoint on the api."""
+        _sensor_output_id, _sensor_output_value = self.get_output_by_pairing(
+            pairing=Pairing.AL_WINDOW_DOOR
+        )
+        return await self._api.set_datapoint(
+            device_id=self.device_id,
+            channel_id=self.channel_id,
+            datapoint=_sensor_output_id,
+            value=value,
+        )

--- a/src/abbfreeathome/devices/virtual/virtual_window_door_sensor.py
+++ b/src/abbfreeathome/devices/virtual/virtual_window_door_sensor.py
@@ -44,13 +44,13 @@ class VirtualWindowDoorSensor(VirtualBase):
         """Get the sensor state."""
         return self._state
 
-    async def set_on(self):
-        """Activate the sensor."""
+    async def turn_on(self):
+        """Turn on the sensor."""
         await self._set_sensor_datapoint("1")
         self._state = True
 
-    async def set_off(self):
-        """Deactivate the sensor."""
+    async def turn_off(self):
+        """Turn off the sensor."""
         await self._set_sensor_datapoint("0")
         self._state = False
 

--- a/tests/test_freeathome.py
+++ b/tests/test_freeathome.py
@@ -9,6 +9,9 @@ from src.abbfreeathome.bin.function import Function
 from src.abbfreeathome.bin.interface import Interface
 from src.abbfreeathome.devices.switch_actuator import SwitchActuator
 from src.abbfreeathome.devices.switch_sensor import SwitchSensor
+from src.abbfreeathome.devices.virtual.virtual_switch_actuator import (
+    VirtualSwitchActuator,
+)
 from src.abbfreeathome.freeathome import FreeAtHome
 
 
@@ -288,6 +291,41 @@ def api_mock():
                 },
                 "parameters": {},
             },
+            # this is a virtual device with no device-class associated
+            "6000123456789": {
+                "deviceReboots": "0",
+                "floor": "01",
+                "room": "01",
+                "displayName": "Virtual Area Rocker",
+                "unresponsive": False,
+                "unresponsiveCounter": 0,
+                "defect": False,
+                "channels": {
+                    "ch0000": {
+                        "floor": "01",
+                        "room": "01",
+                        "displayName": "Virtual Area Rocker",
+                        "functionID": "0",
+                        "inputs": {
+                            "idp0000": {"pairingID": 256, "value": "0"},
+                            "idp0001": {"pairingID": 18, "value": "0"},
+                            "idp0002": {"pairingID": 273, "value": "0"},
+                            "idp0004": {"pairingID": 261, "value": "0"},
+                            "idp0005": {"pairingID": 278, "value": "0"},
+                        },
+                        "outputs": {
+                            "odp0000": {"pairingID": 1, "value": "0"},
+                            "odp0006": {"pairingID": 4, "value": "0"},
+                        },
+                        "parameters": {
+                            "par0002": "50",
+                            "par0001": "50",
+                            "par0007": "1",
+                        },
+                    },
+                },
+                "parameters": {"par00ed": "1"},
+            },
         },
     }
     return api
@@ -459,7 +497,7 @@ async def test_load_devices_with_virtuals(freeathome_virtuals):
     # Check a single virtual device
     device_key = "60005D808C54/ch0000"
     assert device_key in devices
-    assert isinstance(devices[device_key], SwitchActuator)
+    assert isinstance(devices[device_key], VirtualSwitchActuator)
     assert devices[device_key].device_name == "Sleepmode"
     assert devices[device_key].channel_name == "Sleepmode"
     assert devices[device_key].floor_name == "Ground Floor"

--- a/tests/test_virtual_base.py
+++ b/tests/test_virtual_base.py
@@ -1,0 +1,64 @@
+"""Test class to test the VirtualBase device."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from src.abbfreeathome.api import FreeAtHomeApi
+
+# from src.abbfreeathome.bin.pairing import Pairing
+from src.abbfreeathome.devices.virtual.virtual_base import VirtualBase
+
+# from src.abbfreeathome.exceptions import InvalidDeviceChannelPairing
+
+
+@pytest.fixture
+def mock_api():
+    """Create a mock api function."""
+    return MagicMock(spec=FreeAtHomeApi)
+
+
+@pytest.fixture
+def base_instance(mock_api):
+    """Set up the base instance for testing the Base device."""
+    inputs = {
+        "idp0000": {"pairingID": 1, "value": ""},
+        "idp0001": {"pairingID": 2, "value": ""},
+        "idp0002": {"pairingID": 3, "value": ""},
+        "idp0003": {"pairingID": 4, "value": ""},
+        "idp0004": {"pairingID": 6, "value": ""},
+    }
+    outputs = {
+        "odp0000": {"pairingID": 256, "value": "0"},
+        "odp0001": {"pairingID": 257, "value": "0"},
+    }
+    parameters = {}
+
+    return VirtualBase(
+        device_id="60004F56EA24",
+        device_name="Device Name",
+        channel_id="ch0000",
+        channel_name="Channel Name",
+        inputs=inputs,
+        outputs=outputs,
+        parameters=parameters,
+        api=mock_api,
+        floor_name="Ground Floor",
+        room_name="Study",
+    )
+
+
+def test_initialization(base_instance):
+    """Test the initialization of the base class."""
+    assert base_instance.device_id == "60004F56EA24"
+    assert base_instance.device_name == "Device Name"
+    assert base_instance.channel_id == "ch0000"
+    assert base_instance.channel_name == "Channel Name"
+    assert base_instance.floor_name == "Ground Floor"
+    assert base_instance.room_name == "Study"
+
+
+def test_update_device(base_instance):
+    """Test when output-datapoint is provided."""
+
+    base_instance.update_device("AL_INFO_ON_OFF/odp0000", "1")

--- a/tests/test_virtual_switch_actuator.py
+++ b/tests/test_virtual_switch_actuator.py
@@ -53,9 +53,9 @@ async def test_initial_state(virtual_switch_actuator):
 
 
 @pytest.mark.asyncio
-async def test_set_on(virtual_switch_actuator):
+async def test_turn_on(virtual_switch_actuator):
     """Test to turning on of the switch."""
-    await virtual_switch_actuator.set_on()
+    await virtual_switch_actuator.turn_on()
     assert virtual_switch_actuator.state is True
     virtual_switch_actuator._api.set_datapoint.assert_called_with(
         device_id="60004F56EA24",
@@ -66,9 +66,9 @@ async def test_set_on(virtual_switch_actuator):
 
 
 @pytest.mark.asyncio
-async def test_set_off(virtual_switch_actuator):
+async def test_turn_off(virtual_switch_actuator):
     """Test to turning off of the switch."""
-    await virtual_switch_actuator.set_off()
+    await virtual_switch_actuator.turn_off()
     assert virtual_switch_actuator.state is False
     virtual_switch_actuator._api.set_datapoint.assert_called_with(
         device_id="60004F56EA24",

--- a/tests/test_virtual_switch_actuator.py
+++ b/tests/test_virtual_switch_actuator.py
@@ -1,0 +1,161 @@
+"""Test class to test the virtual SwitchActuator device."""
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from src.abbfreeathome.api import FreeAtHomeApi
+from src.abbfreeathome.devices.virtual.virtual_switch_actuator import (
+    VirtualSwitchActuator,
+    VirtualSwitchActuatorForcedPosition,
+)
+
+
+@pytest.fixture
+def mock_api():
+    """Create a mock api function."""
+    return AsyncMock(spec=FreeAtHomeApi)
+
+
+@pytest.fixture
+def virtual_switch_actuator(mock_api):
+    """Set up the switch instance for testing the virtual SwitchActuator device."""
+    inputs = {
+        "idp0000": {"pairingID": 1, "value": "0"},
+        "idp0001": {"pairingID": 2, "value": "0"},
+        "idp0002": {"pairingID": 3, "value": "0"},
+        "idp0003": {"pairingID": 4, "value": "1"},
+        "idp0004": {"pairingID": 6, "value": "0"},
+    }
+    outputs = {
+        "odp0000": {"pairingID": 256, "value": "0"},
+        "odp0001": {"pairingID": 257, "value": "0"},
+        "odp0004": {"pairingID": 273, "value": "0"},
+    }
+    parameters = {}
+
+    return VirtualSwitchActuator(
+        device_id="60004F56EA24",
+        device_name="Device Name",
+        channel_id="ch0000",
+        channel_name="Channel Name",
+        inputs=inputs,
+        outputs=outputs,
+        parameters=parameters,
+        api=mock_api,
+    )
+
+
+@pytest.mark.asyncio
+async def test_initial_state(virtual_switch_actuator):
+    """Test the intial state of the virtual switch."""
+    assert virtual_switch_actuator.state is False
+
+
+@pytest.mark.asyncio
+async def test_set_on(virtual_switch_actuator):
+    """Test to turning on of the switch."""
+    await virtual_switch_actuator.set_on()
+    assert virtual_switch_actuator.state is True
+    virtual_switch_actuator._api.set_datapoint.assert_called_with(
+        device_id="60004F56EA24",
+        channel_id="ch0000",
+        datapoint="odp0000",
+        value="1",
+    )
+
+
+@pytest.mark.asyncio
+async def test_set_off(virtual_switch_actuator):
+    """Test to turning off of the switch."""
+    await virtual_switch_actuator.set_off()
+    assert virtual_switch_actuator.state is False
+    virtual_switch_actuator._api.set_datapoint.assert_called_with(
+        device_id="60004F56EA24",
+        channel_id="ch0000",
+        datapoint="odp0000",
+        value="0",
+    )
+
+
+@pytest.mark.asyncio
+async def test_set_forced_position(virtual_switch_actuator):
+    """Test to set the forced option of the switch."""
+    await virtual_switch_actuator.set_forced_position(
+        VirtualSwitchActuatorForcedPosition.deactivated.name
+    )
+    assert (
+        virtual_switch_actuator.forced_position
+        == VirtualSwitchActuatorForcedPosition.deactivated.name
+    )
+    virtual_switch_actuator._api.set_datapoint.assert_called_with(
+        device_id="60004F56EA24",
+        channel_id="ch0000",
+        datapoint="odp0001",
+        value="0",
+    )
+    await virtual_switch_actuator.set_forced_position(
+        VirtualSwitchActuatorForcedPosition.forced_off.name
+    )
+    assert (
+        virtual_switch_actuator.forced_position
+        == VirtualSwitchActuatorForcedPosition.forced_off.name
+    )
+    virtual_switch_actuator._api.set_datapoint.assert_called_with(
+        device_id="60004F56EA24",
+        channel_id="ch0000",
+        datapoint="odp0001",
+        value="5",
+    )
+    await virtual_switch_actuator.set_forced_position(
+        VirtualSwitchActuatorForcedPosition.forced_on.name
+    )
+    assert (
+        virtual_switch_actuator.forced_position
+        == VirtualSwitchActuatorForcedPosition.forced_on.name
+    )
+    virtual_switch_actuator._api.set_datapoint.assert_called_with(
+        device_id="60004F56EA24",
+        channel_id="ch0000",
+        datapoint="odp0001",
+        value="4",
+    )
+
+    await virtual_switch_actuator.set_forced_position("INVALID")
+    assert (
+        virtual_switch_actuator.forced_position
+        == VirtualSwitchActuatorForcedPosition.unknown.name
+    )
+
+
+@pytest.mark.asyncio
+async def test_refresh_state(virtual_switch_actuator):
+    """Test refreshing the state of the switch."""
+    virtual_switch_actuator._api.get_datapoint.return_value = ["1"]
+    await virtual_switch_actuator.refresh_state()
+    assert virtual_switch_actuator.state is True
+    virtual_switch_actuator._api.get_datapoint.assert_called_with(
+        device_id="60004F56EA24",
+        channel_id="ch0000",
+        datapoint="idp0002",
+    )
+
+
+def test_update_device(virtual_switch_actuator):
+    """Test updating the device state."""
+
+    def test_callback():
+        pass
+
+    # Ensure callback is registered to test callback code.
+    virtual_switch_actuator.register_callback(test_callback)
+
+    virtual_switch_actuator.update_device("AL_SWITCH_ON_OFF/idp0000", "1")
+    assert virtual_switch_actuator.state is True
+
+    virtual_switch_actuator.update_device("AL_SWITCH_ON_OFF/idp0000", "0")
+    assert virtual_switch_actuator.state is False
+
+    # Test scenario where websocket sends update not relevant to the state.
+    virtual_switch_actuator.update_device("AL_SWITCH_ON_OFF/idp0001", "1")
+    assert virtual_switch_actuator.state is False

--- a/tests/test_virtual_window_door_sensor.py
+++ b/tests/test_virtual_window_door_sensor.py
@@ -1,0 +1,63 @@
+"""Test class to test the virtual WindowDoorSensor device."""
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from src.abbfreeathome.api import FreeAtHomeApi
+from src.abbfreeathome.devices.virtual.virtual_window_door_sensor import (
+    VirtualWindowDoorSensor,
+)
+
+
+@pytest.fixture
+def mock_api():
+    """Create a mock api function."""
+    return AsyncMock(spec=FreeAtHomeApi)
+
+
+@pytest.fixture
+def virtual_window_door_sensor(mock_api):
+    """Set up the sensor instance for testing the virtual WindowDoorSensor device."""
+    inputs = {}
+    outputs = {
+        "odp000c": {"pairingID": 53, "value": "0"},
+    }
+    parameters = {}
+
+    return VirtualWindowDoorSensor(
+        device_id="60002AE2F1BE",
+        device_name="Device Name",
+        channel_id="ch0000",
+        channel_name="Channel Name",
+        inputs=inputs,
+        outputs=outputs,
+        parameters=parameters,
+        api=mock_api,
+    )
+
+
+@pytest.mark.asyncio
+async def test_set_on(virtual_window_door_sensor):
+    """Test to activate the sensor."""
+    await virtual_window_door_sensor.set_on()
+    virtual_window_door_sensor._api.set_datapoint.assert_called_with(
+        device_id="60002AE2F1BE",
+        channel_id="ch0000",
+        datapoint="odp000c",
+        value="1",
+    )
+    assert virtual_window_door_sensor.state is True
+
+
+@pytest.mark.asyncio
+async def test_set_off(virtual_window_door_sensor):
+    """Test to deactivate the sensor."""
+    await virtual_window_door_sensor.set_off()
+    virtual_window_door_sensor._api.set_datapoint.assert_called_with(
+        device_id="60002AE2F1BE",
+        channel_id="ch0000",
+        datapoint="odp000c",
+        value="0",
+    )
+    assert virtual_window_door_sensor.state is False

--- a/tests/test_virtual_window_door_sensor.py
+++ b/tests/test_virtual_window_door_sensor.py
@@ -38,9 +38,9 @@ def virtual_window_door_sensor(mock_api):
 
 
 @pytest.mark.asyncio
-async def test_set_on(virtual_window_door_sensor):
+async def test_turn_on(virtual_window_door_sensor):
     """Test to activate the sensor."""
-    await virtual_window_door_sensor.set_on()
+    await virtual_window_door_sensor.turn_on()
     virtual_window_door_sensor._api.set_datapoint.assert_called_with(
         device_id="60002AE2F1BE",
         channel_id="ch0000",
@@ -51,9 +51,9 @@ async def test_set_on(virtual_window_door_sensor):
 
 
 @pytest.mark.asyncio
-async def test_set_off(virtual_window_door_sensor):
+async def test_turn_off(virtual_window_door_sensor):
     """Test to deactivate the sensor."""
-    await virtual_window_door_sensor.set_off()
+    await virtual_window_door_sensor.turn_off()
     virtual_window_door_sensor._api.set_datapoint.assert_called_with(
         device_id="60002AE2F1BE",
         channel_id="ch0000",


### PR DESCRIPTION
This closes #134.

I totally re-thought the "virtual device" problematic, especially regarding a HA integration.

After thinking about extremely complex triggers and actions, I think - at the end - it is way easier. 🤞 

The two current implemented virtual devices:
- VirtualWindowDoorSensor
  - This is in HA nothing else than a switch, turning it on in HA will turn it on in F@H and the other way round
- VirtualSwitchActuator
  - This is a bit more complex as we have a two-way communication
  - The first device in HA will be a switch, turning it on in HA will turn it on in F@H and the other way round
  - The second (!!!) device in HA will be a binary_sensor, turning it on in F@H will turn it on in HA. And here the advanced user needs to create an automation (if binary_sensor is turned on [check whatever is needed] and finally turn on the switch
- I think this also totally complies with the way F@H defines virtual devices -> totally external controlled
