### PR TITLE
Rework callback handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,7 +281,9 @@ async def websocket_test():
 
         # Add our very own callback
         for _switch in _free_at_home.get_devices_by_class(device_class=SwitchActuator):
-            _switch.register_callback(my_very_own_callback)
+            _switch.register_callback(
+                callback_attribute="state", callback=my_very_own_callback
+            )
 
         # Start listening for events.
         await _free_at_home.ws_listen()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ packages = ["src/abbfreeathome"]
 
 [project]
 name = "local-abbfreeathome"
-version = "1.20.0"
+version = "2.0.0"
 authors = [
   { name="Adam Kingsley", email="adam@kingsley.io" },
 ]

--- a/src/abbfreeathome/devices/blind_sensor.py
+++ b/src/abbfreeathome/devices/blind_sensor.py
@@ -25,6 +25,9 @@ class BlindSensor(Base):
         Pairing.AL_MOVE_UP_DOWN,
         Pairing.AL_STOP_STEP_UP_DOWN,
     ]
+    _callback_attributes: list[str] = [
+        "state",
+    ]
 
     def __init__(
         self,
@@ -72,7 +75,7 @@ class BlindSensor(Base):
         """Get the move state property."""
         return self._move_state.name
 
-    def _refresh_state_from_datapoint(self, datapoint: dict[str, Any]) -> bool:
+    def _refresh_state_from_datapoint(self, datapoint: dict[str, Any]) -> str:
         """
         Refresh the state of the device from a given output.
 
@@ -93,7 +96,7 @@ class BlindSensor(Base):
                 self._step_state = BlindSensorState.unknown
 
             self._state = self._step_state
-            return True
+            return "state"
 
         if datapoint.get("pairingID") == Pairing.AL_MOVE_UP_DOWN.value:
             """
@@ -110,5 +113,5 @@ class BlindSensor(Base):
                 self._move_state = BlindSensorState.unknown
 
             self._state = self._move_state
-            return True
-        return False
+            return "state"
+        return None

--- a/src/abbfreeathome/devices/brightness_sensor.py
+++ b/src/abbfreeathome/devices/brightness_sensor.py
@@ -14,6 +14,10 @@ class BrightnessSensor(Base):
         Pairing.AL_BRIGHTNESS_LEVEL,
         Pairing.AL_BRIGHTNESS_ALARM,
     ]
+    _callback_attributes: list[str] = [
+        "state",
+        "alarm",
+    ]
 
     def __init__(
         self,
@@ -55,7 +59,7 @@ class BrightnessSensor(Base):
         """Get the alarm state of the sensor."""
         return self._alarm
 
-    def _refresh_state_from_datapoint(self, datapoint: dict[str, Any]) -> bool:
+    def _refresh_state_from_datapoint(self, datapoint: dict[str, Any]) -> str:
         """
         Refresh the state of the device from a given output.
 
@@ -63,8 +67,8 @@ class BrightnessSensor(Base):
         """
         if datapoint.get("pairingID") == Pairing.AL_BRIGHTNESS_LEVEL.value:
             self._state = float(datapoint.get("value"))
-            return True
+            return "state"
         if datapoint.get("pairingID") == Pairing.AL_BRIGHTNESS_ALARM.value:
             self._alarm = datapoint.get("value") == "1"
-            return True
-        return False
+            return "alarm"
+        return None

--- a/src/abbfreeathome/devices/carbon_monoxide_sensor.py
+++ b/src/abbfreeathome/devices/carbon_monoxide_sensor.py
@@ -13,6 +13,9 @@ class CarbonMonoxideSensor(Base):
     _state_refresh_pairings: list[Pairing] = [
         Pairing.AL_CO_ALARM_ACTIVE,
     ]
+    _callback_attributes: list[str] = [
+        "state",
+    ]
 
     def __init__(
         self,
@@ -48,7 +51,7 @@ class CarbonMonoxideSensor(Base):
         """Get the device state."""
         return self._state
 
-    def _refresh_state_from_datapoint(self, datapoint: dict[str, Any]) -> bool:
+    def _refresh_state_from_datapoint(self, datapoint: dict[str, Any]) -> str:
         """
         Refresh the state of the device from a given output.
 
@@ -56,5 +59,5 @@ class CarbonMonoxideSensor(Base):
         """
         if datapoint.get("pairingID") == Pairing.AL_CO_ALARM_ACTIVE.value:
             self._state = datapoint.get("value") == "1"
-            return True
-        return False
+            return "state"
+        return None

--- a/src/abbfreeathome/devices/cover_actuator.py
+++ b/src/abbfreeathome/devices/cover_actuator.py
@@ -36,6 +36,12 @@ class CoverActuator(Base):
         Pairing.AL_INFO_FORCE,
         Pairing.AL_CURRENT_ABSOLUTE_POSITION_SLATS_PERCENTAGE,
     ]
+    _callback_attributes: list[str] = [
+        "state",
+        "forced_position",
+        "position",
+        "tilt_position",
+    ]
 
     def __init__(
         self,
@@ -130,7 +136,7 @@ class CoverActuator(Base):
         await self._set_position_datapoint(str(value))
         self._position = value
 
-    def _refresh_state_from_datapoint(self, datapoint: dict[str, Any]) -> bool:
+    def _refresh_state_from_datapoint(self, datapoint: dict[str, Any]) -> str:
         """
         Refresh the state of the device from a given output.
 
@@ -141,7 +147,7 @@ class CoverActuator(Base):
                 self._state = CoverActuatorState(datapoint.get("value"))
             except ValueError:
                 self._state = CoverActuatorState.unknown
-            return True
+            return "state"
         if datapoint.get("pairingID") == Pairing.AL_INFO_FORCE.value:
             try:
                 self._forced_position = CoverActuatorForcedPosition(
@@ -149,20 +155,20 @@ class CoverActuator(Base):
                 )
             except ValueError:
                 self._forced_position = CoverActuatorForcedPosition.unknown
-            return True
+            return "forced_position"
         if (
             datapoint.get("pairingID")
             == Pairing.AL_CURRENT_ABSOLUTE_POSITION_BLINDS_PERCENTAGE.value
         ):
             self._position = int(float(datapoint.get("value")))
-            return True
+            return "position"
         if (
             datapoint.get("pairingID")
             == Pairing.AL_CURRENT_ABSOLUTE_POSITION_SLATS_PERCENTAGE.value
         ):
             self._tilt_position = int(float(datapoint.get("value")))
-            return True
-        return False
+            return "tilt_position"
+        return None
 
     async def _set_moving_datapoint(self, value: str):
         """Set the move_up_down datapoint on the api."""

--- a/src/abbfreeathome/devices/des_door_opener_actuator.py
+++ b/src/abbfreeathome/devices/des_door_opener_actuator.py
@@ -13,6 +13,9 @@ class DesDoorOpenerActuator(Base):
     _state_refresh_pairings: list[Pairing] = [
         Pairing.AL_INFO_ON_OFF,
     ]
+    _callback_attributes: list[str] = [
+        "state",
+    ]
 
     def __init__(
         self,
@@ -58,7 +61,7 @@ class DesDoorOpenerActuator(Base):
         await self._set_switching_datapoint("1")
         self._state = True
 
-    def _refresh_state_from_datapoint(self, datapoint: dict[str, Any]) -> bool:
+    def _refresh_state_from_datapoint(self, datapoint: dict[str, Any]) -> str:
         """
         Refresh the state of the device from a given output.
 
@@ -66,8 +69,8 @@ class DesDoorOpenerActuator(Base):
         """
         if datapoint.get("pairingID") == Pairing.AL_INFO_ON_OFF.value:
             self._state = datapoint.get("value") == "1"
-            return True
-        return False
+            return "state"
+        return None
 
     async def _set_switching_datapoint(self, value: str):
         """Set the switching datapoint on the api."""

--- a/src/abbfreeathome/devices/des_door_ringing_sensor.py
+++ b/src/abbfreeathome/devices/des_door_ringing_sensor.py
@@ -13,6 +13,9 @@ class DesDoorRingingSensor(Base):
     _state_refresh_pairings: list[Pairing] = [
         Pairing.AL_TIMED_START_STOP,
     ]
+    _callback_attributes: list[str] = [
+        "state",
+    ]
 
     def __init__(
         self,
@@ -41,10 +44,12 @@ class DesDoorRingingSensor(Base):
             room_name,
         )
 
-    def _refresh_state_from_datapoint(self, datapoint: dict[str, Any]) -> bool:
+    def _refresh_state_from_datapoint(self, datapoint: dict[str, Any]) -> str:
         """
         Refresh the state of the device from a given output.
 
         This will return whether the state was refreshed as a boolean value.
         """
-        return datapoint.get("pairingID") == Pairing.AL_TIMED_START_STOP.value
+        if datapoint.get("pairingID") == Pairing.AL_TIMED_START_STOP.value:
+            return "state"
+        return None

--- a/src/abbfreeathome/devices/dimming_actuator.py
+++ b/src/abbfreeathome/devices/dimming_actuator.py
@@ -25,6 +25,11 @@ class DimmingActuator(Base):
         Pairing.AL_INFO_ON_OFF,
         Pairing.AL_INFO_ACTUAL_DIMMING_VALUE,
     ]
+    _callback_attributes: list[str] = [
+        "state",
+        "brightness",
+        "forced_position",
+    ]
 
     def __init__(
         self,
@@ -113,7 +118,7 @@ class DimmingActuator(Base):
 
         self._forced_position = _position
 
-    def _refresh_state_from_datapoint(self, datapoint: dict[str, Any]) -> bool:
+    def _refresh_state_from_datapoint(self, datapoint: dict[str, Any]) -> str:
         """
         Refresh the state of the device from a given output.
 
@@ -121,10 +126,10 @@ class DimmingActuator(Base):
         """
         if datapoint.get("pairingID") == Pairing.AL_INFO_ON_OFF.value:
             self._state = datapoint.get("value") == "1"
-            return True
+            return "state"
         if datapoint.get("pairingID") == Pairing.AL_INFO_ACTUAL_DIMMING_VALUE.value:
             self._brightness = int(float(datapoint.get("value")))
-            return True
+            return "brightness"
         if datapoint.get("pairingID") == Pairing.AL_INFO_FORCE.value:
             try:
                 self._forced_position = DimmingActuatorForcedPosition(
@@ -132,8 +137,8 @@ class DimmingActuator(Base):
                 )
             except ValueError:
                 self._forced_position = DimmingActuatorForcedPosition.unknown
-            return True
-        return False
+            return "forced_position"
+        return None
 
     async def _set_switching_datapoint(self, value: str):
         """Set the switching datapoint on the api."""

--- a/src/abbfreeathome/devices/force_on_off_sensor.py
+++ b/src/abbfreeathome/devices/force_on_off_sensor.py
@@ -22,6 +22,9 @@ class ForceOnOffSensor(Base):
     _state_refresh_pairings: list[Pairing] = [
         Pairing.AL_FORCED,
     ]
+    _callback_attributes: list[str] = [
+        "state",
+    ]
 
     def __init__(
         self,
@@ -57,7 +60,7 @@ class ForceOnOffSensor(Base):
         """Get the forceOnOff state."""
         return self._state.name
 
-    def _refresh_state_from_datapoint(self, datapoint: dict[str, Any]) -> bool:
+    def _refresh_state_from_datapoint(self, datapoint: dict[str, Any]) -> str:
         """
         Refresh the state of the device from a given output.
 
@@ -80,5 +83,5 @@ class ForceOnOffSensor(Base):
                 self._state = ForceOnOffSensorState.off
             else:
                 self._state = ForceOnOffSensorState.unknown
-            return True
-        return False
+            return "state"
+        return None

--- a/src/abbfreeathome/devices/heating_actuator.py
+++ b/src/abbfreeathome/devices/heating_actuator.py
@@ -13,6 +13,9 @@ class HeatingActuator(Base):
     _state_refresh_pairings: list[Pairing] = [
         Pairing.AL_INFO_VALUE_HEATING,
     ]
+    _callback_attributes: list[str] = [
+        "position",
+    ]
 
     def __init__(
         self,
@@ -62,7 +65,7 @@ class HeatingActuator(Base):
         await self._set_position_datapoint(str(value))
         self._position = value
 
-    def _refresh_state_from_datapoint(self, datapoint: dict[str, Any]) -> bool:
+    def _refresh_state_from_datapoint(self, datapoint: dict[str, Any]) -> str:
         """
         Refresh the state of the device from a given output.
 
@@ -70,8 +73,8 @@ class HeatingActuator(Base):
         """
         if datapoint.get("pairingID") == Pairing.AL_INFO_VALUE_HEATING.value:
             self._position = int(float(datapoint.get("value")))
-            return True
-        return False
+            return "position"
+        return None
 
     async def _set_position_datapoint(self, value: str):
         """Set the position datapoint on the api."""

--- a/src/abbfreeathome/devices/movement_detector.py
+++ b/src/abbfreeathome/devices/movement_detector.py
@@ -14,6 +14,10 @@ class MovementDetector(Base):
         Pairing.AL_BRIGHTNESS_LEVEL,
         Pairing.AL_TIMED_MOVEMENT,
     ]
+    _callback_attributes: list[str] = [
+        "state",
+        "brightness",
+    ]
 
     def __init__(
         self,
@@ -55,7 +59,7 @@ class MovementDetector(Base):
         """Get the brightness level of the sensor."""
         return self._brightness
 
-    def _refresh_state_from_datapoint(self, datapoint: dict[str, Any]) -> bool:
+    def _refresh_state_from_datapoint(self, datapoint: dict[str, Any]) -> str:
         """
         Refresh the state of the device from a given output.
 
@@ -63,8 +67,8 @@ class MovementDetector(Base):
         """
         if datapoint.get("pairingID") == Pairing.AL_TIMED_MOVEMENT.value:
             self._state = datapoint.get("value") == "1"
-            return True
+            return "state"
         if datapoint.get("pairingID") == Pairing.AL_BRIGHTNESS_LEVEL.value:
             self._brightness = float(datapoint.get("value"))
-            return True
-        return False
+            return "brightness"
+        return None

--- a/src/abbfreeathome/devices/rain_sensor.py
+++ b/src/abbfreeathome/devices/rain_sensor.py
@@ -13,6 +13,9 @@ class RainSensor(Base):
     _state_refresh_pairings: list[Pairing] = [
         Pairing.AL_RAIN_ALARM,
     ]
+    _callback_attributes: list[str] = [
+        "state",
+    ]
 
     def __init__(
         self,
@@ -48,7 +51,7 @@ class RainSensor(Base):
         """Get the rain alarm of the sensor."""
         return self._state
 
-    def _refresh_state_from_datapoint(self, datapoint: dict[str, Any]) -> bool:
+    def _refresh_state_from_datapoint(self, datapoint: dict[str, Any]) -> str:
         """
         Refresh the state of the device from a given output.
 
@@ -56,5 +59,5 @@ class RainSensor(Base):
         """
         if datapoint.get("pairingID") == Pairing.AL_RAIN_ALARM.value:
             self._state = datapoint.get("value") == "1"
-            return True
-        return False
+            return "state"
+        return None

--- a/src/abbfreeathome/devices/smoke_detector.py
+++ b/src/abbfreeathome/devices/smoke_detector.py
@@ -13,6 +13,9 @@ class SmokeDetector(Base):
     _state_refresh_pairings: list[Pairing] = [
         Pairing.AL_FIRE_ALARM_ACTIVE,
     ]
+    _callback_attributes: list[str] = [
+        "state",
+    ]
 
     def __init__(
         self,
@@ -48,7 +51,7 @@ class SmokeDetector(Base):
         """Get the device state."""
         return self._state
 
-    def _refresh_state_from_datapoint(self, datapoint: dict[str, Any]) -> bool:
+    def _refresh_state_from_datapoint(self, datapoint: dict[str, Any]) -> str:
         """
         Refresh the state of the device from a given output.
 
@@ -56,5 +59,5 @@ class SmokeDetector(Base):
         """
         if datapoint.get("pairingID") == Pairing.AL_FIRE_ALARM_ACTIVE.value:
             self._state = datapoint.get("value") == "1"
-            return True
-        return False
+            return "state"
+        return None

--- a/src/abbfreeathome/devices/switch_actuator.py
+++ b/src/abbfreeathome/devices/switch_actuator.py
@@ -24,6 +24,10 @@ class SwitchActuator(Base):
         Pairing.AL_INFO_FORCE,
         Pairing.AL_INFO_ON_OFF,
     ]
+    _callback_attributes: list[str] = [
+        "state",
+        "forced_position",
+    ]
 
     def __init__(
         self,
@@ -93,7 +97,7 @@ class SwitchActuator(Base):
 
         self._forced_position = _position
 
-    def _refresh_state_from_datapoint(self, datapoint: dict[str, Any]) -> bool:
+    def _refresh_state_from_datapoint(self, datapoint: dict[str, Any]) -> str:
         """
         Refresh the state of the device from a given output.
 
@@ -101,7 +105,7 @@ class SwitchActuator(Base):
         """
         if datapoint.get("pairingID") == Pairing.AL_INFO_ON_OFF.value:
             self._state = datapoint.get("value") == "1"
-            return True
+            return "state"
         if datapoint.get("pairingID") == Pairing.AL_INFO_FORCE.value:
             try:
                 self._forced_position = SwitchActuatorForcedPosition(
@@ -109,8 +113,8 @@ class SwitchActuator(Base):
                 )
             except ValueError:
                 self._forced_position = SwitchActuatorForcedPosition.unknown
-            return True
-        return False
+            return "forced_position"
+        return None
 
     async def _set_switching_datapoint(self, value: str):
         """Set the switching datapoint on the api."""

--- a/src/abbfreeathome/devices/switch_sensor.py
+++ b/src/abbfreeathome/devices/switch_sensor.py
@@ -33,6 +33,9 @@ class SwitchSensor(Base):
         Pairing.AL_RELATIVE_SET_VALUE_CONTROL,
         Pairing.AL_SWITCH_ON_OFF,
     ]
+    _callback_attributes: list[str] = [
+        "state",
+    ]
 
     def __init__(
         self,
@@ -75,7 +78,7 @@ class SwitchSensor(Base):
         """Get the switch state."""
         return self._switch_sensor_state.name
 
-    def _refresh_state_from_datapoint(self, datapoint: dict[str, Any]) -> bool:
+    def _refresh_state_from_datapoint(self, datapoint: dict[str, Any]) -> str:
         """
         Refresh the state of the device from a given output.
 
@@ -88,8 +91,8 @@ class SwitchSensor(Base):
                 self._switch_sensor_state = SwitchSensorState.unknown
 
             self._state = self._switch_sensor_state
-            return True
-        return False
+            return "state"
+        return None
 
 
 class DimmingSensor(SwitchSensor):
@@ -100,14 +103,15 @@ class DimmingSensor(SwitchSensor):
         """Get the dimming state."""
         return self._dimming_sensor_state.name
 
-    def _refresh_state_from_datapoint(self, datapoint: dict[str, Any]) -> bool:
+    def _refresh_state_from_datapoint(self, datapoint: dict[str, Any]) -> str:
         """
         Refresh the state of the device from a given output.
 
         This will return whether the state was refreshed as a boolean value.
         """
-        if super()._refresh_state_from_datapoint(datapoint):
-            return True
+        _return_value = super()._refresh_state_from_datapoint(datapoint)
+        if _return_value is not None:
+            return _return_value
 
         if datapoint.get("pairingID") == Pairing.AL_RELATIVE_SET_VALUE_CONTROL.value:
             try:
@@ -116,5 +120,5 @@ class DimmingSensor(SwitchSensor):
                 self._dimming_sensor_state = DimmingSensorState.unknown
 
             self._state = self._dimming_sensor_state
-            return True
-        return False
+            return "state"
+        return None

--- a/src/abbfreeathome/devices/temperature_sensor.py
+++ b/src/abbfreeathome/devices/temperature_sensor.py
@@ -14,6 +14,10 @@ class TemperatureSensor(Base):
         Pairing.AL_OUTDOOR_TEMPERATURE,
         Pairing.AL_FROST_ALARM,
     ]
+    _callback_attributes: list[str] = [
+        "state",
+        "alarm",
+    ]
 
     def __init__(
         self,
@@ -63,8 +67,8 @@ class TemperatureSensor(Base):
         """
         if datapoint.get("pairingID") == Pairing.AL_OUTDOOR_TEMPERATURE.value:
             self._state = float(datapoint.get("value"))
-            return True
+            return "state"
         if datapoint.get("pairingID") == Pairing.AL_FROST_ALARM.value:
             self._alarm = datapoint.get("value") == "1"
-            return True
-        return False
+            return "alarm"
+        return None

--- a/src/abbfreeathome/devices/wind_sensor.py
+++ b/src/abbfreeathome/devices/wind_sensor.py
@@ -15,6 +15,11 @@ class WindSensor(Base):
         Pairing.AL_WIND_ALARM,
         Pairing.AL_WIND_FORCE,
     ]
+    _callback_attributes: list[str] = [
+        "state",
+        "alarm",
+        "force",
+    ]
 
     def __init__(
         self,
@@ -62,7 +67,7 @@ class WindSensor(Base):
         """Get the force state of the sensor."""
         return self._force
 
-    def _refresh_state_from_datapoint(self, datapoint: dict[str, Any]) -> bool:
+    def _refresh_state_from_datapoint(self, datapoint: dict[str, Any]) -> str:
         """
         Refresh the state of the device from a given output.
 
@@ -70,11 +75,11 @@ class WindSensor(Base):
         """
         if datapoint.get("pairingID") == Pairing.AL_WIND_SPEED.value:
             self._state = float(datapoint.get("value"))
-            return True
+            return "state"
         if datapoint.get("pairingID") == Pairing.AL_WIND_ALARM.value:
             self._alarm = datapoint.get("value") == "1"
-            return True
+            return "alarm"
         if datapoint.get("pairingID") == Pairing.AL_WIND_FORCE.value:
             self._force = int(datapoint.get("value"))
-            return True
-        return False
+            return "force"
+        return None

--- a/src/abbfreeathome/devices/window_door_sensor.py
+++ b/src/abbfreeathome/devices/window_door_sensor.py
@@ -27,6 +27,10 @@ class WindowDoorSensor(Base):
     _state_refresh_pairings: list[Pairing] = [
         Pairing.AL_WINDOW_DOOR,
     ]
+    _callback_attributes: list[str] = [
+        "state",
+        "position",
+    ]
 
     def __init__(
         self,
@@ -68,7 +72,7 @@ class WindowDoorSensor(Base):
         """Get the sensor position."""
         return self._position.name
 
-    def _refresh_state_from_datapoint(self, datapoint: dict[str, Any]) -> bool:
+    def _refresh_state_from_datapoint(self, datapoint: dict[str, Any]) -> str:
         """
         Refresh the state of the device from a given output.
 
@@ -76,11 +80,11 @@ class WindowDoorSensor(Base):
         """
         if datapoint.get("pairingID") == Pairing.AL_WINDOW_DOOR.value:
             self._state = datapoint.get("value") == "1"
-            return True
+            return "state"
         if datapoint.get("pairingID") == Pairing.AL_WINDOW_DOOR_POSITION.value:
             try:
                 self._position = WindowDoorSensorPosition(datapoint.get("value"))
             except ValueError:
                 self._position = WindowDoorSensorPosition.unknown
-            return True
-        return False
+            return "position"
+        return None

--- a/src/abbfreeathome/exceptions.py
+++ b/src/abbfreeathome/exceptions.py
@@ -95,3 +95,18 @@ class SetDatapointFailureException(FreeAtHomeException):
             f"value: {value}"
         )
         super().__init__(self.message)
+
+
+class UnknownCallbackAttributeException(FreeAtHomeException):
+    """Raise an exception when an unknown callback-attribute should be registered."""
+
+    def __init__(self, unknown_attribute: str, known_attributes: str):
+        """Initialize the UnknownCallbackAttributeException class."""
+        self.message = (
+            f"Tried to register the callback-atrribute: "
+            f"{unknown_attribute}"
+            f", but only the callback-attributes '"
+            f"{known_attributes}"
+            f"' are known."
+        )
+        super().__init__(self.message)

--- a/tests/test_des_door_ringing_sensor.py
+++ b/tests/test_des_door_ringing_sensor.py
@@ -42,11 +42,11 @@ def test_refresh_state_from_datapoint(des_door_ringing_sensor):
         des_door_ringing_sensor._refresh_state_from_datapoint(
             datapoint={"pairingID": 2, "value": "1"},
         )
-        is True
+        == "state"
     )
     assert (
         des_door_ringing_sensor._refresh_state_from_datapoint(
             datapoint={"pairingID": 4, "value": "1"},
         )
-        is False
+        is None
     )

--- a/tests/test_dimming_actuator.py
+++ b/tests/test_dimming_actuator.py
@@ -188,7 +188,9 @@ def test_update_device(dimming_actuator):
         pass
 
     # Ensure callback is registered to test callback code.
-    dimming_actuator.register_callback(test_callback)
+    dimming_actuator.register_callback(
+        callback_attribute="state", callback=test_callback
+    )
 
     dimming_actuator.update_device("AL_INFO_ON_OFF/odp0000", "1")
     assert dimming_actuator.state is True
@@ -197,5 +199,5 @@ def test_update_device(dimming_actuator):
     assert dimming_actuator.state is False
 
     # Test scenario where websocket sends update not relevant to the state.
-    dimming_actuator.update_device("AL_INFO_ON_OFF/odp0001", "1")
+    dimming_actuator.update_device("AL_INFO_ON_OFF/odp0004", "1")
     assert dimming_actuator.state is False

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -10,6 +10,7 @@ from src.abbfreeathome.exceptions import (
     InvalidDeviceChannelPairing,
     InvalidHostException,
     SetDatapointFailureException,
+    UnknownCallbackAttributeException,
     UserNotFoundException,
 )
 
@@ -80,4 +81,19 @@ def test_set_datapoint_failure_exception():
     assert str(excinfo.value) == (
         "Failed to set datapoint; "
         "device_id: device1; channel_id: channel1; datapoint: datapoint1; value: value1"
+    )
+
+
+def test_unknown_callback_attribute_exception():
+    """Test the unknown callback attribute exception."""
+    with pytest.raises(UnknownCallbackAttributeException) as excinfo:
+        raise UnknownCallbackAttributeException(
+            unknown_attribute="not_there", known_attributes="there"
+        )
+    assert str(excinfo.value) == (
+        "Tried to register the callback-atrribute: "
+        "not_there"
+        ", but only the callback-attributes '"
+        "there"
+        "' are known."
     )

--- a/tests/test_room_temperature_controller.py
+++ b/tests/test_room_temperature_controller.py
@@ -205,7 +205,9 @@ def test_update_device(room_temperature_controller):
         pass
 
     # Ensure callback is registered to test callback code
-    room_temperature_controller.register_callback(test_callback)
+    room_temperature_controller.register_callback(
+        callback_attribute="state", callback=test_callback
+    )
 
     room_temperature_controller.update_device("AL_CONTROLLER_ON_OFF/odp0008", "0")
     assert room_temperature_controller.state is False

--- a/tests/test_switch_actuator.py
+++ b/tests/test_switch_actuator.py
@@ -142,7 +142,9 @@ def test_update_device(switch_actuator):
         pass
 
     # Ensure callback is registered to test callback code.
-    switch_actuator.register_callback(test_callback)
+    switch_actuator.register_callback(
+        callback_attribute="state", callback=test_callback
+    )
 
     switch_actuator.update_device("AL_INFO_ON_OFF/odp0000", "1")
     assert switch_actuator.state is True
@@ -151,5 +153,5 @@ def test_update_device(switch_actuator):
     assert switch_actuator.state is False
 
     # Test scenario where websocket sends update not relevant to the state.
-    switch_actuator.update_device("AL_INFO_ON_OFF/odp0001", "1")
+    switch_actuator.update_device("AL_INFO_ON_OFF/odp0004", "1")
     assert switch_actuator.state is False


### PR DESCRIPTION
This pull-request reworks the callback handling.

When registering a callback for a device it needs to be specified now for which attribute-change the callback should be fired.
Before:
```
device.register_callback(callback=my_callback)
```

Now:
```
device.register_callback(callback_attribute="state", callback=my_callback)
```

The same applies to the removal of a callback.

Each device exposes, for which attributes a callback can be registered. If a registration is performed for an unknown attribute an exception is raised.

As this is a major change, the major version number will be increased.