### PR TITLE
Bugfix: Add interface `smokealarm` after firmware upgrade to 3.5.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ packages = ["src/abbfreeathome"]
 
 [project]
 name = "local-abbfreeathome"
-version = "2.1.1"
+version = "2.1.2"
 authors = [
   { name="Adam Kingsley", email="adam@kingsley.io" },
 ]

--- a/src/abbfreeathome/bin/interface.py
+++ b/src/abbfreeathome/bin/interface.py
@@ -17,3 +17,4 @@ class Interface(enum.Enum):
     HUE = "hue"
     SONOS = "sonos"
     VIRTUAL_DEVICE = "VD"
+    SMOKEALARM = "smokealarm"


### PR DESCRIPTION
This will fix a problem introduced with firmware 3.5.0 (see #178). It should be backward-safe. The lower firmwares used `UNDEFINED` as interface