### PR TITLE
Bugfix: Reassign FID_BLINDS_ACTUATOR_TYPE0 to ShutterActuator

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ packages = ["src/abbfreeathome"]
 
 [project]
 name = "local-abbfreeathome"
-version = "2.2.0"
+version = "2.2.1"
 authors = [
   { name="Adam Kingsley", email="adam@kingsley.io" },
 ]

--- a/src/abbfreeathome/const.py
+++ b/src/abbfreeathome/const.py
@@ -40,7 +40,7 @@ FUNCTION_DEVICE_MAPPING: dict[Function, Base] = {
     Function.FID_ATTIC_WINDOW_ACTUATOR: AtticWindowActuator,
     Function.FID_AWNING_ACTUATOR: AwningActuator,
     Function.FID_BLIND_ACTUATOR: BlindActuator,
-    Function.FID_BLINDS_ACTUATOR_TYPE0: BlindActuator,
+    Function.FID_BLINDS_ACTUATOR_TYPE0: ShutterActuator,
     Function.FID_BLINDS_ACTUATOR_TYPE1: BlindActuator,
     Function.FID_BLINDS_ACTUATOR_TYPE2: BlindActuator,
     Function.FID_BLINDS_ACTUATOR_TYPE3: BlindActuator,


### PR DESCRIPTION
In https://github.com/kingsleyadam/local-abbfreeathome/issues/168#issuecomment-2721751480 we made - at least partly - a wrong assumption.

This relates partly to https://github.com/kingsleyadam/local-abbfreeathome-hass/issues/140