### PR TITLE
Ensure ForbiddenAuthException shows correct status

### DIFF
--- a/src/abbfreeathome/api.py
+++ b/src/abbfreeathome/api.py
@@ -308,7 +308,7 @@ class FreeAtHomeApi:
             if e.status == 401:
                 raise InvalidCredentialsException(self._auth.login) from e
             if e.status == 403:
-                raise ForbiddenAuthException(path) from e
+                raise ForbiddenAuthException(path, e.status) from e
             if e.status == 502:
                 raise ConnectionTimeoutException(self._host) from e
             raise InvalidApiResponseException(e.status) from e

--- a/src/abbfreeathome/exceptions.py
+++ b/src/abbfreeathome/exceptions.py
@@ -26,9 +26,13 @@ class ConnectionTimeoutException(FreeAtHomeException):
 class ForbiddenAuthException(FreeAtHomeException):
     """Raise an exception if the connection returns a forbidden code."""
 
-    def __init__(self, path) -> None:
+    def __init__(self, path, status_code) -> None:
         """Initialze the ForbiddenAuthException class."""
-        self.message = f"Request returned a forbidden (401) error message: {path}"
+        self.message = (
+            "Request returned a forbidden error message "
+            f"(status code: {status_code}): "
+            f"{path}"
+        )
         super().__init__(self.message)
 
 

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -27,10 +27,10 @@ def test_connection_timeout_exception():
 def test_forbidden_auth_exception():
     """Test forbidden auth exception."""
     with pytest.raises(ForbiddenAuthException) as excinfo:
-        raise ForbiddenAuthException("/api/path")
+        raise ForbiddenAuthException(path="/api/path", status_code=403)
     assert (
         str(excinfo.value)
-        == "Request returned a forbidden (401) error message: /api/path"
+        == "Request returned a forbidden error message (status code: 403): /api/path"
     )
 
 


### PR DESCRIPTION
Closes #184, ensure the correct status code is raised on ForbiddenAuthException.