### PR TITLE
Add device class, device implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -362,22 +362,7 @@ async def main():
 
     # Iterate through devices
     for _device in _devices.values():
-        print(f"Device: {_device.display_name}")
-        print(f"  Serial: {_device.device_serial}")
-        print(f"  Interface: {_device.interface}")
-        print(f"  Virtual: {_device.is_virtual}")
-        print(f"  Status: {'Unresponsive' if _device.unresponsive else 'Online'}")
-        print(
-            f"  Location: {_device.floor_name or _device.floor}, "
-            f"{_device.room_name or _device.room}"
-        )
-        print(f"  Floor: {_device.floor} ({_device.floor_name})")
-        print(f"  Room: {_device.room} ({_device.room_name})")
-        print(f"  Channels: {len(_device.channels)}")
-
-        # Access additional attributes if needed
-        if _device.device_reboots:
-            print(f"  Reboots: {_device.device_reboots}")
+        print(str(_device))
 
     # Number of devices
     print(f"\nFound {len(_devices)} devices")

--- a/README.md
+++ b/README.md
@@ -342,59 +342,62 @@ Here is example code that'll output all of the devices in your Free@Home setup. 
 ```python
 import asyncio
 
-from abbfreeathome import FreeAtHome, FreeAtHomeApi
-from abbfreeathome.bin.interface import Interface
+from src.abbfreeathome import FreeAtHome, FreeAtHomeApi
+from src.abbfreeathome.bin.interface import Interface
 
 
 async def main():
-    # Initialize the API and FreeAtHome
-    api = FreeAtHomeApi(
-        host="http://<IP or HOSTNAME>", username="installer", password="<password>"
+    # Create an instance of the FreeAtHome class.
+    _free_at_home = FreeAtHome(
+        api=FreeAtHomeApi(
+          host="http://<IP or HOSTNAME>", username="installer", password="<password>"
+        )
     )
-    fah = FreeAtHome(api)
 
     # Load devices and channels
-    await fah.load()
+    await _free_at_home.load()
 
     # Get all devices
-    devices = fah.get_devices()
+    _devices = _free_at_home.get_devices()
 
     # Iterate through devices
-    for device in devices.values():
-        print(f"Device: {device.display_name}")
-        print(f"  Serial: {device.device_serial}")
-        print(f"  Interface: {device.interface}")
-        print(f"  Virtual: {device.is_virtual}")
-        print(f"  Status: {'Unresponsive' if device.unresponsive else 'Online'}")
+    for _device in _devices.values():
+        print(f"Device: {_device.display_name}")
+        print(f"  Serial: {_device.device_serial}")
+        print(f"  Interface: {_device.interface}")
+        print(f"  Virtual: {_device.is_virtual}")
+        print(f"  Status: {'Unresponsive' if _device.unresponsive else 'Online'}")
         print(
-            f"  Location: {device.floor_name or device.floor}, "
-            f"{device.room_name or device.room}"
+            f"  Location: {_device.floor_name or _device.floor}, "
+            f"{_device.room_name or _device.room}"
         )
-        print(f"  Floor: {device.floor} ({device.floor_name})")
-        print(f"  Room: {device.room} ({device.room_name})")
-        print(f"  Channels: {len(device.channels)}")
+        print(f"  Floor: {_device.floor} ({_device.floor_name})")
+        print(f"  Room: {_device.room} ({_device.room_name})")
+        print(f"  Channels: {len(_device.channels)}")
 
         # Access additional attributes if needed
-        if device.device_reboots:
-            print(f"  Reboots: {device.device_reboots}")
+        if _device.device_reboots:
+            print(f"  Reboots: {_device.device_reboots}")
 
     # Number of devices
-    print(f"\nFound {len(devices)} devices")
-    # Unresponsive devices
-    unresponsive_devices = [
-        device for device in devices.values() if device.unresponsive
-    ]
-    print(f"Unresponsive devices: {len(unresponsive_devices)}\n")
+    print(f"\nFound {len(_devices)} devices")
 
+    # Unresponsive devices
+    _unresponsive_devices = [
+        device for device in _devices.values() if device.unresponsive
+    ]
+    print(f"Unresponsive devices: {len(_unresponsive_devices)}\n")
+
+    # Filter devices by interface using the Interface enum
     # Devices by interface
     for _interface in Interface:
-        _devices = [
-            device for device in devices.values() if device.interface == _interface
+        _device_by_interface = [
+            _device for _device in _devices.values() if _device.interface == _interface
         ]
-        print(f"{_interface} devices: {len(_devices)}")
+        print(f"{_interface} devices: {len(_device_by_interface)}")
 
     # Close api session
-    await api.close_client_session()
+    await _free_at_home.api.close_client_session()
 
 
 if __name__ == "__main__":

--- a/README.md
+++ b/README.md
@@ -335,6 +335,72 @@ INFO:abbfreeathome.channels.base:Office Light received updated data: ABB7F62F6C2
 The switches datapoints have been updated.
 ```
 
+### Devices / Free@Home Overview
+
+Here is example code that'll output all of the devices in your Free@Home setup. Including some general information about the setup (e.g. number of devices, unresponsive devices, counts by interfact)
+
+```python
+import asyncio
+
+from abbfreeathome import FreeAtHome, FreeAtHomeApi
+from abbfreeathome.bin.interface import Interface
+
+
+async def main():
+    # Initialize the API and FreeAtHome
+    api = FreeAtHomeApi(
+        host="http://<IP or HOSTNAME>", username="installer", password="<password>"
+    )
+    fah = FreeAtHome(api)
+
+    # Load devices and channels
+    await fah.load()
+
+    # Get all devices
+    devices = fah.get_devices()
+
+    # Iterate through devices
+    for device in devices.values():
+        print(f"Device: {device.display_name}")
+        print(f"  Serial: {device.device_serial}")
+        print(f"  Interface: {device.interface}")
+        print(f"  Virtual: {device.is_virtual}")
+        print(f"  Status: {'Unresponsive' if device.unresponsive else 'Online'}")
+        print(
+            f"  Location: {device.floor_name or device.floor}, "
+            f"{device.room_name or device.room}"
+        )
+        print(f"  Floor: {device.floor} ({device.floor_name})")
+        print(f"  Room: {device.room} ({device.room_name})")
+        print(f"  Channels: {len(device.channels)}")
+
+        # Access additional attributes if needed
+        if device.device_reboots:
+            print(f"  Reboots: {device.device_reboots}")
+
+    # Number of devices
+    print(f"\nFound {len(devices)} devices")
+    # Unresponsive devices
+    unresponsive_devices = [
+        device for device in devices.values() if device.unresponsive
+    ]
+    print(f"Unresponsive devices: {len(unresponsive_devices)}\n")
+
+    # Devices by interface
+    for _interface in Interface:
+        _devices = [
+            device for device in devices.values() if device.interface == _interface
+        ]
+        print(f"{_interface} devices: {len(_devices)}")
+
+    # Close api session
+    await api.close_client_session()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())
+```
+
 ## TODO
 
 There are a number of items that still need to be done.

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ async def refresh_state(self):
 
         _datapoint = (
             await self._api.get_datapoint(
-                device_id=self.device_id,
+                device_serial=self.device_serial,
                 channel_id=self.channel_id,
                 datapoint=_switch_output_id,
             )
@@ -160,7 +160,7 @@ async def _set_switching_datapoint(self, value: str):
         pairing=Pairing.AL_SWITCH_ON_OFF
     )
     return await self._api.set_datapoint(
-        device_id=self.device_id,
+        device_serial=self.device_serial,
         channel_id=self.channel_id,
         datapoint=_switch_input_id,
         value=value,

--- a/src/abbfreeathome/__init__.py
+++ b/src/abbfreeathome/__init__.py
@@ -1,1 +1,6 @@
+"""ABB-Free@Home API library."""
 
+from .api import FreeAtHomeApi
+from .freeathome import FreeAtHome
+
+__all__ = ["FreeAtHomeApi", "FreeAtHome"]

--- a/src/abbfreeathome/api.py
+++ b/src/abbfreeathome/api.py
@@ -198,11 +198,11 @@ class FreeAtHomeApi:
         return _response.get(self._sysap_uuid)
 
     async def get_datapoint(
-        self, device_id: str, channel_id: str, datapoint: str
+        self, device_serial: str, channel_id: str, datapoint: str
     ) -> list[str]:
         """Get a specific datapoint from the api."""
         _response = await self._request(
-            path=f"/api/rest/datapoint/{self._sysap_uuid}/{device_id}.{channel_id}.{datapoint}",
+            path=f"/api/rest/datapoint/{self._sysap_uuid}/{device_serial}.{channel_id}.{datapoint}",
             method="get",
         )
 
@@ -227,17 +227,19 @@ class FreeAtHomeApi:
         return await self._request(path="/api/rest/sysap")
 
     async def set_datapoint(
-        self, device_id: str, channel_id: str, datapoint: str, value: str
+        self, device_serial: str, channel_id: str, datapoint: str, value: str
     ) -> bool:
         """Set a specific datapoint in the api. This is used to control channels."""
         _response = await self._request(
-            path=f"/api/rest/datapoint/{self._sysap_uuid}/{device_id}.{channel_id}.{datapoint}",
+            path=f"/api/rest/datapoint/{self._sysap_uuid}/{device_serial}.{channel_id}.{datapoint}",
             method="put",
             data=value,
         )
 
         if _response.get(self._sysap_uuid).get("result").lower() != "ok":
-            raise SetDatapointFailureException(device_id, channel_id, datapoint, value)
+            raise SetDatapointFailureException(
+                device_serial, channel_id, datapoint, value
+            )
 
         return True
 

--- a/src/abbfreeathome/bin/interface.py
+++ b/src/abbfreeathome/bin/interface.py
@@ -18,3 +18,11 @@ class Interface(enum.Enum):
     SONOS = "sonos"
     VIRTUAL_DEVICE = "VD"
     SMOKEALARM = "smokealarm"
+
+    @classmethod
+    def from_string(cls, interface_value: str | None) -> "Interface":
+        """Convert an interface string to an Interface enum."""
+        for interface in cls:
+            if interface.value == interface_value:
+                return interface
+        return cls.UNDEFINED

--- a/src/abbfreeathome/channels/base.py
+++ b/src/abbfreeathome/channels/base.py
@@ -24,7 +24,7 @@ class Base:
 
     def __init__(
         self,
-        device_id: str,
+        device_serial: str,
         device_name: str,
         channel_id: str,
         channel_name: str,
@@ -36,7 +36,7 @@ class Base:
         room_name: str | None = None,
     ) -> None:
         """Initialize the Free@Home Base class."""
-        self._device_id = device_id
+        self._device_serial = device_serial
         self._device_name = device_name
         self._channel_id = channel_id
         self._channel_name = channel_name
@@ -52,9 +52,9 @@ class Base:
         self._refresh_state_from_datapoints()
 
     @property
-    def device_id(self) -> str:
-        """Get the device id."""
-        return self._device_id
+    def device_serial(self) -> str:
+        """Get the device serial."""
+        return self._device_serial
 
     @property
     def device_name(self) -> str:
@@ -84,7 +84,7 @@ class Base:
     @property
     def is_virtual(self) -> bool | None:
         """Get the virtual-status of the device."""
-        return self.device_id[0:4] == "6000"
+        return self.device_serial[0:4] == "6000"
 
     def get_input_by_pairing(self, pairing: Pairing) -> tuple[str, Any]:
         """Get the channel input by pairing id."""
@@ -93,7 +93,7 @@ class Base:
                 return _input_id, _input.get("value")
 
         raise InvalidDeviceChannelPairing(
-            self.device_id, self.channel_id, pairing.value
+            self.device_serial, self.channel_id, pairing.value
         )
 
     def get_output_by_pairing(self, pairing: Pairing) -> tuple[str, Any]:
@@ -103,7 +103,7 @@ class Base:
                 return _output_id, _output.get("value")
 
         raise InvalidDeviceChannelPairing(
-            self.device_id, self.channel_id, pairing.value
+            self.device_serial, self.channel_id, pairing.value
         )
 
     def get_channel_parameter(self, parameter: Parameter) -> tuple[str, Any]:
@@ -114,7 +114,7 @@ class Base:
                 return _parameter_id, _parameter_value
 
         raise InvalidDeviceChannelParameter(
-            self.device_id, self.channel_id, parameter.name
+            self.device_serial, self.channel_id, parameter.name
         )
 
     def update_channel(self, datapoint_key: str, datapoint_value: str):
@@ -169,7 +169,7 @@ class Base:
 
             _datapoint = (
                 await self._api.get_datapoint(
-                    device_id=self.device_id,
+                    device_serial=self.device_serial,
                     channel_id=self.channel_id,
                     datapoint=_datapoint_id,
                 )

--- a/src/abbfreeathome/channels/blind_sensor.py
+++ b/src/abbfreeathome/channels/blind_sensor.py
@@ -31,7 +31,7 @@ class BlindSensor(Base):
 
     def __init__(
         self,
-        device_id: str,
+        device_serial: str,
         device_name: str,
         channel_id: str,
         channel_name: str,
@@ -48,7 +48,7 @@ class BlindSensor(Base):
         self._move_state: BlindSensorState = BlindSensorState.unknown
 
         super().__init__(
-            device_id,
+            device_serial,
             device_name,
             channel_id,
             channel_name,

--- a/src/abbfreeathome/channels/brightness_sensor.py
+++ b/src/abbfreeathome/channels/brightness_sensor.py
@@ -21,7 +21,7 @@ class BrightnessSensor(Base):
 
     def __init__(
         self,
-        device_id: str,
+        device_serial: str,
         device_name: str,
         channel_id: str,
         channel_name: str,
@@ -37,7 +37,7 @@ class BrightnessSensor(Base):
         self._alarm: bool | None = None
 
         super().__init__(
-            device_id,
+            device_serial,
             device_name,
             channel_id,
             channel_name,

--- a/src/abbfreeathome/channels/carbon_monoxide_sensor.py
+++ b/src/abbfreeathome/channels/carbon_monoxide_sensor.py
@@ -19,7 +19,7 @@ class CarbonMonoxideSensor(Base):
 
     def __init__(
         self,
-        device_id: str,
+        device_serial: str,
         device_name: str,
         channel_id: str,
         channel_name: str,
@@ -34,7 +34,7 @@ class CarbonMonoxideSensor(Base):
         self._state: bool | None = None
 
         super().__init__(
-            device_id,
+            device_serial,
             device_name,
             channel_id,
             channel_name,

--- a/src/abbfreeathome/channels/cover_actuator.py
+++ b/src/abbfreeathome/channels/cover_actuator.py
@@ -43,7 +43,7 @@ class CoverActuator(Base):
 
     def __init__(
         self,
-        device_id: str,
+        device_serial: str,
         device_name: str,
         channel_id: str,
         channel_name: str,
@@ -62,7 +62,7 @@ class CoverActuator(Base):
         )
 
         super().__init__(
-            device_id,
+            device_serial,
             device_name,
             channel_id,
             channel_name,
@@ -167,7 +167,7 @@ class CoverActuator(Base):
             pairing=Pairing.AL_MOVE_UP_DOWN
         )
         return await self._api.set_datapoint(
-            device_id=self.device_id,
+            device_serial=self.device_serial,
             channel_id=self.channel_id,
             datapoint=_move_input_id,
             value=value,
@@ -179,7 +179,7 @@ class CoverActuator(Base):
             pairing=Pairing.AL_SET_ABSOLUTE_POSITION_BLINDS_PERCENTAGE
         )
         return await self._api.set_datapoint(
-            device_id=self.device_id,
+            device_serial=self.device_serial,
             channel_id=self.channel_id,
             datapoint=_position_input_id,
             value=value,
@@ -191,7 +191,7 @@ class CoverActuator(Base):
             pairing=Pairing.AL_FORCED_UP_DOWN
         )
         return await self._api.set_datapoint(
-            device_id=self.device_id,
+            device_serial=self.device_serial,
             channel_id=self.channel_id,
             datapoint=_force_input_id,
             value=value,
@@ -203,7 +203,7 @@ class CoverActuator(Base):
             pairing=Pairing.AL_STOP_STEP_UP_DOWN
         )
         return await self._api.set_datapoint(
-            device_id=self.device_id,
+            device_serial=self.device_serial,
             channel_id=self.channel_id,
             datapoint=_stop_input_id,
             value="1",
@@ -240,7 +240,7 @@ class ShutterActuator(CoverActuator):
 
     def __init__(
         self,
-        device_id: str,
+        device_serial: str,
         device_name: str,
         channel_id: str,
         channel_name: str,
@@ -255,7 +255,7 @@ class ShutterActuator(CoverActuator):
         self._tilt_position: int | None = None
 
         super().__init__(
-            device_id,
+            device_serial,
             device_name,
             channel_id,
             channel_name,
@@ -310,7 +310,7 @@ class ShutterActuator(CoverActuator):
             pairing=Pairing.AL_SET_ABSOLUTE_POSITION_SLATS_PERCENTAGE
         )
         return await self._api.set_datapoint(
-            device_id=self.device_id,
+            device_serial=self.device_serial,
             channel_id=self.channel_id,
             datapoint=_tilt_input_id,
             value=value,

--- a/src/abbfreeathome/channels/des_door_opener_actuator.py
+++ b/src/abbfreeathome/channels/des_door_opener_actuator.py
@@ -19,7 +19,7 @@ class DesDoorOpenerActuator(Base):
 
     def __init__(
         self,
-        device_id: str,
+        device_serial: str,
         device_name: str,
         channel_id: str,
         channel_name: str,
@@ -34,7 +34,7 @@ class DesDoorOpenerActuator(Base):
         self._state: bool | None = None
 
         super().__init__(
-            device_id,
+            device_serial,
             device_name,
             channel_id,
             channel_name,
@@ -78,7 +78,7 @@ class DesDoorOpenerActuator(Base):
             pairing=Pairing.AL_TIMED_START_STOP
         )
         return await self._api.set_datapoint(
-            device_id=self.device_id,
+            device_serial=self.device_serial,
             channel_id=self.channel_id,
             datapoint=_switch_input_id,
             value=value,

--- a/src/abbfreeathome/channels/des_door_ringing_sensor.py
+++ b/src/abbfreeathome/channels/des_door_ringing_sensor.py
@@ -19,7 +19,7 @@ class DesDoorRingingSensor(Base):
 
     def __init__(
         self,
-        device_id: str,
+        device_serial: str,
         device_name: str,
         channel_id: str,
         channel_name: str,
@@ -32,7 +32,7 @@ class DesDoorRingingSensor(Base):
     ) -> None:
         """Initialize the Free@Home DesDoorRingingSensor class."""
         super().__init__(
-            device_id,
+            device_serial,
             device_name,
             channel_id,
             channel_name,

--- a/src/abbfreeathome/channels/dimming_actuator.py
+++ b/src/abbfreeathome/channels/dimming_actuator.py
@@ -34,7 +34,7 @@ class DimmingActuator(Base):
 
     def __init__(
         self,
-        device_id: str,
+        device_serial: str,
         device_name: str,
         channel_id: str,
         channel_name: str,
@@ -53,7 +53,7 @@ class DimmingActuator(Base):
         )
 
         super().__init__(
-            device_id,
+            device_serial,
             device_name,
             channel_id,
             channel_name,
@@ -147,7 +147,7 @@ class DimmingActuator(Base):
             pairing=Pairing.AL_SWITCH_ON_OFF
         )
         return await self._api.set_datapoint(
-            device_id=self.device_id,
+            device_serial=self.device_serial,
             channel_id=self.channel_id,
             datapoint=_switch_input_id,
             value=value,
@@ -159,7 +159,7 @@ class DimmingActuator(Base):
             pairing=Pairing.AL_ABSOLUTE_SET_VALUE_CONTROL
         )
         return await self._api.set_datapoint(
-            device_id=self.device_id,
+            device_serial=self.device_serial,
             channel_id=self.channel_id,
             datapoint=_brightness_input_id,
             value=value,
@@ -171,7 +171,7 @@ class DimmingActuator(Base):
             pairing=Pairing.AL_FORCED
         )
         return await self._api.set_datapoint(
-            device_id=self.device_id,
+            device_serial=self.device_serial,
             channel_id=self.channel_id,
             datapoint=_force_input_id,
             value=value,
@@ -196,7 +196,7 @@ class ColorTemperatureActuator(DimmingActuator):
 
     def __init__(
         self,
-        device_id: str,
+        device_serial: str,
         device_name: str,
         channel_id: str,
         channel_name: str,
@@ -211,7 +211,7 @@ class ColorTemperatureActuator(DimmingActuator):
         self._color_temperature: int | None = None
 
         super().__init__(
-            device_id,
+            device_serial,
             device_name,
             channel_id,
             channel_name,
@@ -276,7 +276,7 @@ class ColorTemperatureActuator(DimmingActuator):
             pairing=Pairing.AL_COLOR_TEMPERATURE
         )
         return await self._api.set_datapoint(
-            device_id=self._device_id,
+            device_serial=self.device_serial,
             channel_id=self.channel_id,
             datapoint=_color_temp_id,
             value=value,

--- a/src/abbfreeathome/channels/force_on_off_sensor.py
+++ b/src/abbfreeathome/channels/force_on_off_sensor.py
@@ -28,7 +28,7 @@ class ForceOnOffSensor(Base):
 
     def __init__(
         self,
-        device_id: str,
+        device_serial: str,
         device_name: str,
         channel_id: str,
         channel_name: str,
@@ -43,7 +43,7 @@ class ForceOnOffSensor(Base):
         self._state: ForceOnOffSensorState = ForceOnOffSensorState.unknown
 
         super().__init__(
-            device_id,
+            device_serial,
             device_name,
             channel_id,
             channel_name,

--- a/src/abbfreeathome/channels/heating_actuator.py
+++ b/src/abbfreeathome/channels/heating_actuator.py
@@ -19,7 +19,7 @@ class HeatingActuator(Base):
 
     def __init__(
         self,
-        device_id: str,
+        device_serial: str,
         device_name: str,
         channel_id: str,
         channel_name: str,
@@ -34,7 +34,7 @@ class HeatingActuator(Base):
         self._position: int | None = None
 
         super().__init__(
-            device_id,
+            device_serial,
             device_name,
             channel_id,
             channel_name,
@@ -82,7 +82,7 @@ class HeatingActuator(Base):
             pairing=Pairing.AL_ACTUATING_VALUE_HEATING
         )
         return await self._api.set_datapoint(
-            device_id=self.device_id,
+            device_serial=self.device_serial,
             channel_id=self.channel_id,
             datapoint=_position_input_id,
             value=value,

--- a/src/abbfreeathome/channels/movement_detector.py
+++ b/src/abbfreeathome/channels/movement_detector.py
@@ -21,7 +21,7 @@ class MovementDetector(Base):
 
     def __init__(
         self,
-        device_id: str,
+        device_serial: str,
         device_name: str,
         channel_id: str,
         channel_name: str,
@@ -37,7 +37,7 @@ class MovementDetector(Base):
         self._brightness: float | None = None
 
         super().__init__(
-            device_id,
+            device_serial,
             device_name,
             channel_id,
             channel_name,

--- a/src/abbfreeathome/channels/rain_sensor.py
+++ b/src/abbfreeathome/channels/rain_sensor.py
@@ -19,7 +19,7 @@ class RainSensor(Base):
 
     def __init__(
         self,
-        device_id: str,
+        device_serial: str,
         device_name: str,
         channel_id: str,
         channel_name: str,
@@ -34,7 +34,7 @@ class RainSensor(Base):
         self._state: bool | None = None
 
         super().__init__(
-            device_id,
+            device_serial,
             device_name,
             channel_id,
             channel_name,

--- a/src/abbfreeathome/channels/room_temperature_controller.py
+++ b/src/abbfreeathome/channels/room_temperature_controller.py
@@ -29,7 +29,7 @@ class RoomTemperatureController(Base):
 
     def __init__(
         self,
-        device_id: str,
+        device_serial: str,
         device_name: str,
         channel_id: str,
         channel_name: str,
@@ -50,7 +50,7 @@ class RoomTemperatureController(Base):
         self._eco_mode: bool | None = None
 
         super().__init__(
-            device_id,
+            device_serial,
             device_name,
             channel_id,
             channel_name,
@@ -182,7 +182,7 @@ class RoomTemperatureController(Base):
             pairing=Pairing.AL_CONTROLLER_ON_OFF_REQUEST
         )
         return await self._api.set_datapoint(
-            device_id=self.device_id,
+            device_serial=self.device_serial,
             channel_id=self.channel_id,
             datapoint=_switch_input_id,
             value=value,
@@ -194,7 +194,7 @@ class RoomTemperatureController(Base):
             pairing=Pairing.AL_ECO_ON_OFF
         )
         return await self._api.set_datapoint(
-            device_id=self.device_id,
+            device_serial=self.device_serial,
             channel_id=self.channel_id,
             datapoint=_eco_input_id,
             value=value,
@@ -206,7 +206,7 @@ class RoomTemperatureController(Base):
             pairing=Pairing.AL_INFO_ABSOLUTE_SET_POINT_REQUEST
         )
         return await self._api.set_datapoint(
-            device_id=self.device_id,
+            device_serial=self.device_serial,
             channel_id=self.channel_id,
             datapoint=_temperature_input_id,
             value=value,

--- a/src/abbfreeathome/channels/smoke_detector.py
+++ b/src/abbfreeathome/channels/smoke_detector.py
@@ -19,7 +19,7 @@ class SmokeDetector(Base):
 
     def __init__(
         self,
-        device_id: str,
+        device_serial: str,
         device_name: str,
         channel_id: str,
         channel_name: str,
@@ -34,7 +34,7 @@ class SmokeDetector(Base):
         self._state: bool | None = None
 
         super().__init__(
-            device_id,
+            device_serial,
             device_name,
             channel_id,
             channel_name,

--- a/src/abbfreeathome/channels/switch_actuator.py
+++ b/src/abbfreeathome/channels/switch_actuator.py
@@ -31,7 +31,7 @@ class SwitchActuator(Base):
 
     def __init__(
         self,
-        device_id: str,
+        device_serial: str,
         device_name: str,
         channel_id: str,
         channel_name: str,
@@ -49,7 +49,7 @@ class SwitchActuator(Base):
         )
 
         super().__init__(
-            device_id,
+            device_serial,
             device_name,
             channel_id,
             channel_name,
@@ -122,7 +122,7 @@ class SwitchActuator(Base):
             pairing=Pairing.AL_SWITCH_ON_OFF
         )
         return await self._api.set_datapoint(
-            device_id=self.device_id,
+            device_serial=self.device_serial,
             channel_id=self.channel_id,
             datapoint=_switch_input_id,
             value=value,
@@ -134,7 +134,7 @@ class SwitchActuator(Base):
             pairing=Pairing.AL_FORCED
         )
         return await self._api.set_datapoint(
-            device_id=self.device_id,
+            device_serial=self.device_serial,
             channel_id=self.channel_id,
             datapoint=_force_input_id,
             value=value,

--- a/src/abbfreeathome/channels/switch_sensor.py
+++ b/src/abbfreeathome/channels/switch_sensor.py
@@ -44,7 +44,7 @@ class SwitchSensor(Base):
 
     def __init__(
         self,
-        device_id: str,
+        device_serial: str,
         device_name: str,
         channel_id: str,
         channel_name: str,
@@ -61,7 +61,7 @@ class SwitchSensor(Base):
         self._led: bool | None = None
 
         super().__init__(
-            device_id,
+            device_serial,
             device_name,
             channel_id,
             channel_name,
@@ -130,7 +130,7 @@ class SwitchSensor(Base):
             pairing=Pairing.AL_INFO_ON_OFF
         )
         return await self._api.set_datapoint(
-            device_id=self.device_id,
+            device_serial=self.device_serial,
             channel_id=self.channel_id,
             datapoint=_sensor_input_id,
             value=value,
@@ -163,7 +163,7 @@ class SwitchSensor(Base):
 
             _datapoint = (
                 await self._api.get_datapoint(
-                    device_id=self.device_id,
+                    device_serial=self.device_serial,
                     channel_id=self.channel_id,
                     datapoint=_datapoint_id,
                 )
@@ -194,7 +194,7 @@ class DimmingSensor(SwitchSensor):
 
     def __init__(
         self,
-        device_id: str,
+        device_serial: str,
         device_name: str,
         channel_id: str,
         channel_name: str,
@@ -210,7 +210,7 @@ class DimmingSensor(SwitchSensor):
         self._dimming_sensor_state: DimmingSensorState = DimmingSensorState.unknown
 
         super().__init__(
-            device_id,
+            device_serial,
             device_name,
             channel_id,
             channel_name,

--- a/src/abbfreeathome/channels/temperature_sensor.py
+++ b/src/abbfreeathome/channels/temperature_sensor.py
@@ -21,7 +21,7 @@ class TemperatureSensor(Base):
 
     def __init__(
         self,
-        device_id: str,
+        device_serial: str,
         device_name: str,
         channel_id: str,
         channel_name: str,
@@ -37,7 +37,7 @@ class TemperatureSensor(Base):
         self._alarm: bool | None = None
 
         super().__init__(
-            device_id,
+            device_serial,
             device_name,
             channel_id,
             channel_name,

--- a/src/abbfreeathome/channels/trigger.py
+++ b/src/abbfreeathome/channels/trigger.py
@@ -15,7 +15,7 @@ class Trigger(Base):
 
     def __init__(
         self,
-        device_id: str,
+        device_serial: str,
         device_name: str,
         channel_id: str,
         channel_name: str,
@@ -28,7 +28,7 @@ class Trigger(Base):
     ) -> None:
         """Initialize the Free@Home Trigger class."""
         super().__init__(
-            device_id,
+            device_serial,
             device_name,
             channel_id,
             channel_name,
@@ -49,7 +49,7 @@ class Trigger(Base):
             pairing=Pairing.AL_TIMED_START_STOP
         )
         return await self._api.set_datapoint(
-            device_id=self.device_id,
+            device_serial=self.device_serial,
             channel_id=self.channel_id,
             datapoint=_trigger_input_id,
             value="1",

--- a/src/abbfreeathome/channels/virtual/virtual_brightness_sensor.py
+++ b/src/abbfreeathome/channels/virtual/virtual_brightness_sensor.py
@@ -21,7 +21,7 @@ class VirtualBrightnessSensor(Base):
 
     def __init__(
         self,
-        device_id: str,
+        device_serial: str,
         device_name: str,
         channel_id: str,
         channel_name: str,
@@ -37,7 +37,7 @@ class VirtualBrightnessSensor(Base):
         self._alarm: bool | None = None
 
         super().__init__(
-            device_id,
+            device_serial,
             device_name,
             channel_id,
             channel_name,
@@ -104,7 +104,7 @@ class VirtualBrightnessSensor(Base):
             pairing=Pairing.AL_BRIGHTNESS_LEVEL
         )
         return await self._api.set_datapoint(
-            device_id=self.device_id,
+            device_serial=self.device_serial,
             channel_id=self.channel_id,
             datapoint=_sensor_output_id,
             value=value,
@@ -116,7 +116,7 @@ class VirtualBrightnessSensor(Base):
             pairing=Pairing.AL_BRIGHTNESS_ALARM
         )
         return await self._api.set_datapoint(
-            device_id=self.device_id,
+            device_serial=self.device_serial,
             channel_id=self.channel_id,
             datapoint=_sensor_output_id,
             value=value,

--- a/src/abbfreeathome/channels/virtual/virtual_energy_battery.py
+++ b/src/abbfreeathome/channels/virtual/virtual_energy_battery.py
@@ -29,7 +29,7 @@ class VirtualEnergyBattery(Base):
 
     def __init__(
         self,
-        device_id: str,
+        device_serial: str,
         device_name: str,
         channel_id: str,
         channel_name: str,
@@ -49,7 +49,7 @@ class VirtualEnergyBattery(Base):
         self._exported_total: int | None = None
 
         super().__init__(
-            device_id,
+            device_serial,
             device_name,
             channel_id,
             channel_name,
@@ -211,7 +211,7 @@ class VirtualEnergyBattery(Base):
             pairing=Pairing.AL_BATTERY_POWER
         )
         return await self._api.set_datapoint(
-            device_id=self.device_id,
+            device_serial=self.device_serial,
             channel_id=self.channel_id,
             datapoint=_sensor_output_id,
             value=value,
@@ -223,7 +223,7 @@ class VirtualEnergyBattery(Base):
             pairing=Pairing.AL_SOC
         )
         return await self._api.set_datapoint(
-            device_id=self.device_id,
+            device_serial=self.device_serial,
             channel_id=self.channel_id,
             datapoint=_sensor_output_id,
             value=value,
@@ -235,7 +235,7 @@ class VirtualEnergyBattery(Base):
             pairing=Pairing.AL_MEASURED_IMPORTED_ENERGY_TODAY
         )
         return await self._api.set_datapoint(
-            device_id=self.device_id,
+            device_serial=self.device_serial,
             channel_id=self.channel_id,
             datapoint=_sensor_output_id,
             value=value,
@@ -247,7 +247,7 @@ class VirtualEnergyBattery(Base):
             pairing=Pairing.AL_MEASURED_EXPORTED_ENERGY_TODAY
         )
         return await self._api.set_datapoint(
-            device_id=self.device_id,
+            device_serial=self.device_serial,
             channel_id=self.channel_id,
             datapoint=_sensor_output_id,
             value=value,
@@ -259,7 +259,7 @@ class VirtualEnergyBattery(Base):
             pairing=Pairing.AL_MEASURED_TOTAL_ENERGY_IMPORTED
         )
         return await self._api.set_datapoint(
-            device_id=self.device_id,
+            device_serial=self.device_serial,
             channel_id=self.channel_id,
             datapoint=_sensor_output_id,
             value=value,
@@ -271,7 +271,7 @@ class VirtualEnergyBattery(Base):
             pairing=Pairing.AL_MEASURED_TOTAL_ENERGY_EXPORTED
         )
         return await self._api.set_datapoint(
-            device_id=self.device_id,
+            device_serial=self.device_serial,
             channel_id=self.channel_id,
             datapoint=_sensor_output_id,
             value=value,

--- a/src/abbfreeathome/channels/virtual/virtual_energy_inverter.py
+++ b/src/abbfreeathome/channels/virtual/virtual_energy_inverter.py
@@ -23,7 +23,7 @@ class VirtualEnergyInverter(Base):
 
     def __init__(
         self,
-        device_id: str,
+        device_serial: str,
         device_name: str,
         channel_id: str,
         channel_name: str,
@@ -40,7 +40,7 @@ class VirtualEnergyInverter(Base):
         self._imported_total: int | None = None
 
         super().__init__(
-            device_id,
+            device_serial,
             device_name,
             channel_id,
             channel_name,
@@ -134,7 +134,7 @@ class VirtualEnergyInverter(Base):
             pairing=Pairing.AL_MEASURED_CURRENT_POWER_CONSUMED
         )
         return await self._api.set_datapoint(
-            device_id=self.device_id,
+            device_serial=self.device_serial,
             channel_id=self.channel_id,
             datapoint=_sensor_output_id,
             value=value,
@@ -146,7 +146,7 @@ class VirtualEnergyInverter(Base):
             pairing=Pairing.AL_MEASURED_IMPORTED_ENERGY_TODAY
         )
         return await self._api.set_datapoint(
-            device_id=self.device_id,
+            device_serial=self.device_serial,
             channel_id=self.channel_id,
             datapoint=_sensor_output_id,
             value=value,
@@ -158,7 +158,7 @@ class VirtualEnergyInverter(Base):
             pairing=Pairing.AL_MEASURED_TOTAL_ENERGY_IMPORTED
         )
         return await self._api.set_datapoint(
-            device_id=self.device_id,
+            device_serial=self.device_serial,
             channel_id=self.channel_id,
             datapoint=_sensor_output_id,
             value=value,

--- a/src/abbfreeathome/channels/virtual/virtual_energy_two_way_meter.py
+++ b/src/abbfreeathome/channels/virtual/virtual_energy_two_way_meter.py
@@ -27,7 +27,7 @@ class VirtualEnergyTwoWayMeter(Base):
 
     def __init__(
         self,
-        device_id: str,
+        device_serial: str,
         device_name: str,
         channel_id: str,
         channel_name: str,
@@ -46,7 +46,7 @@ class VirtualEnergyTwoWayMeter(Base):
         self._exported_total: int | None = None
 
         super().__init__(
-            device_id,
+            device_serial,
             device_name,
             channel_id,
             channel_name,
@@ -188,7 +188,7 @@ class VirtualEnergyTwoWayMeter(Base):
             pairing=Pairing.AL_MEASURED_CURRENT_POWER_CONSUMED
         )
         return await self._api.set_datapoint(
-            device_id=self.device_id,
+            device_serial=self.device_serial,
             channel_id=self.channel_id,
             datapoint=_sensor_output_id,
             value=value,
@@ -200,7 +200,7 @@ class VirtualEnergyTwoWayMeter(Base):
             pairing=Pairing.AL_MEASURED_IMPORTED_ENERGY_TODAY
         )
         return await self._api.set_datapoint(
-            device_id=self.device_id,
+            device_serial=self.device_serial,
             channel_id=self.channel_id,
             datapoint=_sensor_output_id,
             value=value,
@@ -212,7 +212,7 @@ class VirtualEnergyTwoWayMeter(Base):
             pairing=Pairing.AL_MEASURED_EXPORTED_ENERGY_TODAY
         )
         return await self._api.set_datapoint(
-            device_id=self.device_id,
+            device_serial=self.device_serial,
             channel_id=self.channel_id,
             datapoint=_sensor_output_id,
             value=value,
@@ -224,7 +224,7 @@ class VirtualEnergyTwoWayMeter(Base):
             pairing=Pairing.AL_MEASURED_TOTAL_ENERGY_IMPORTED
         )
         return await self._api.set_datapoint(
-            device_id=self.device_id,
+            device_serial=self.device_serial,
             channel_id=self.channel_id,
             datapoint=_sensor_output_id,
             value=value,
@@ -236,7 +236,7 @@ class VirtualEnergyTwoWayMeter(Base):
             pairing=Pairing.AL_MEASURED_TOTAL_ENERGY_EXPORTED
         )
         return await self._api.set_datapoint(
-            device_id=self.device_id,
+            device_serial=self.device_serial,
             channel_id=self.channel_id,
             datapoint=_sensor_output_id,
             value=value,

--- a/src/abbfreeathome/channels/virtual/virtual_rain_sensor.py
+++ b/src/abbfreeathome/channels/virtual/virtual_rain_sensor.py
@@ -19,7 +19,7 @@ class VirtualRainSensor(Base):
 
     def __init__(
         self,
-        device_id: str,
+        device_serial: str,
         device_name: str,
         channel_id: str,
         channel_name: str,
@@ -34,7 +34,7 @@ class VirtualRainSensor(Base):
         self._alarm: bool | None = None
 
         super().__init__(
-            device_id,
+            device_serial,
             device_name,
             channel_id,
             channel_name,
@@ -79,7 +79,7 @@ class VirtualRainSensor(Base):
             pairing=Pairing.AL_RAIN_ALARM
         )
         return await self._api.set_datapoint(
-            device_id=self.device_id,
+            device_serial=self.device_serial,
             channel_id=self.channel_id,
             datapoint=_sensor_output_id,
             value=value,

--- a/src/abbfreeathome/channels/virtual/virtual_switch_actuator.py
+++ b/src/abbfreeathome/channels/virtual/virtual_switch_actuator.py
@@ -28,7 +28,7 @@ class VirtualSwitchActuator(Base):
 
     def __init__(
         self,
-        device_id: str,
+        device_serial: str,
         device_name: str,
         channel_id: str,
         channel_name: str,
@@ -44,7 +44,7 @@ class VirtualSwitchActuator(Base):
         self._requested_state: bool | None = None
 
         super().__init__(
-            device_id,
+            device_serial,
             device_name,
             channel_id,
             channel_name,
@@ -96,7 +96,7 @@ class VirtualSwitchActuator(Base):
             pairing=Pairing.AL_INFO_ON_OFF
         )
         return await self._api.set_datapoint(
-            device_id=self.device_id,
+            device_serial=self.device_serial,
             channel_id=self.channel_id,
             datapoint=_switch_output_id,
             value=value,

--- a/src/abbfreeathome/channels/virtual/virtual_temperature_sensor.py
+++ b/src/abbfreeathome/channels/virtual/virtual_temperature_sensor.py
@@ -21,7 +21,7 @@ class VirtualTemperatureSensor(Base):
 
     def __init__(
         self,
-        device_id: str,
+        device_serial: str,
         device_name: str,
         channel_id: str,
         channel_name: str,
@@ -37,7 +37,7 @@ class VirtualTemperatureSensor(Base):
         self._alarm: bool | None = None
 
         super().__init__(
-            device_id,
+            device_serial,
             device_name,
             channel_id,
             channel_name,
@@ -98,7 +98,7 @@ class VirtualTemperatureSensor(Base):
             pairing=Pairing.AL_OUTDOOR_TEMPERATURE
         )
         return await self._api.set_datapoint(
-            device_id=self.device_id,
+            device_serial=self.device_serial,
             channel_id=self.channel_id,
             datapoint=_sensor_output_id,
             value=value,
@@ -110,7 +110,7 @@ class VirtualTemperatureSensor(Base):
             pairing=Pairing.AL_FROST_ALARM
         )
         return await self._api.set_datapoint(
-            device_id=self.device_id,
+            device_serial=self.device_serial,
             channel_id=self.channel_id,
             datapoint=_sensor_output_id,
             value=value,

--- a/src/abbfreeathome/channels/virtual/virtual_wind_sensor.py
+++ b/src/abbfreeathome/channels/virtual/virtual_wind_sensor.py
@@ -23,7 +23,7 @@ class VirtualWindSensor(Base):
 
     def __init__(
         self,
-        device_id: str,
+        device_serial: str,
         device_name: str,
         channel_id: str,
         channel_name: str,
@@ -40,7 +40,7 @@ class VirtualWindSensor(Base):
         self._force: int | None = None
 
         super().__init__(
-            device_id,
+            device_serial,
             device_name,
             channel_id,
             channel_name,
@@ -131,7 +131,7 @@ class VirtualWindSensor(Base):
             pairing=Pairing.AL_WIND_SPEED
         )
         return await self._api.set_datapoint(
-            device_id=self.device_id,
+            device_serial=self.device_serial,
             channel_id=self.channel_id,
             datapoint=_sensor_output_id,
             value=value,
@@ -143,7 +143,7 @@ class VirtualWindSensor(Base):
             pairing=Pairing.AL_WIND_ALARM
         )
         return await self._api.set_datapoint(
-            device_id=self.device_id,
+            device_serial=self.device_serial,
             channel_id=self.channel_id,
             datapoint=_sensor_output_id,
             value=value,
@@ -155,7 +155,7 @@ class VirtualWindSensor(Base):
             pairing=Pairing.AL_WIND_FORCE
         )
         return await self._api.set_datapoint(
-            device_id=self.device_id,
+            device_serial=self.device_serial,
             channel_id=self.channel_id,
             datapoint=_sensor_output_id,
             value=value,

--- a/src/abbfreeathome/channels/virtual/virtual_window_door_sensor.py
+++ b/src/abbfreeathome/channels/virtual/virtual_window_door_sensor.py
@@ -19,7 +19,7 @@ class VirtualWindowDoorSensor(Base):
 
     def __init__(
         self,
-        device_id: str,
+        device_serial: str,
         device_name: str,
         channel_id: str,
         channel_name: str,
@@ -34,7 +34,7 @@ class VirtualWindowDoorSensor(Base):
         self._state: bool | None = None
 
         super().__init__(
-            device_id,
+            device_serial,
             device_name,
             channel_id,
             channel_name,
@@ -79,7 +79,7 @@ class VirtualWindowDoorSensor(Base):
             pairing=Pairing.AL_WINDOW_DOOR
         )
         return await self._api.set_datapoint(
-            device_id=self.device_id,
+            device_serial=self.device_serial,
             channel_id=self.channel_id,
             datapoint=_sensor_output_id,
             value=value,

--- a/src/abbfreeathome/channels/wind_sensor.py
+++ b/src/abbfreeathome/channels/wind_sensor.py
@@ -23,7 +23,7 @@ class WindSensor(Base):
 
     def __init__(
         self,
-        device_id: str,
+        device_serial: str,
         device_name: str,
         channel_id: str,
         channel_name: str,
@@ -40,7 +40,7 @@ class WindSensor(Base):
         self._force: int | None = None
 
         super().__init__(
-            device_id,
+            device_serial,
             device_name,
             channel_id,
             channel_name,

--- a/src/abbfreeathome/channels/window_door_sensor.py
+++ b/src/abbfreeathome/channels/window_door_sensor.py
@@ -34,7 +34,7 @@ class WindowDoorSensor(Base):
 
     def __init__(
         self,
-        device_id: str,
+        device_serial: str,
         device_name: str,
         channel_id: str,
         channel_name: str,
@@ -50,7 +50,7 @@ class WindowDoorSensor(Base):
         self._position: WindowDoorSensorPosition = WindowDoorSensorPosition.unknown
 
         super().__init__(
-            device_id,
+            device_serial,
             device_name,
             channel_id,
             channel_name,

--- a/src/abbfreeathome/device.py
+++ b/src/abbfreeathome/device.py
@@ -1,0 +1,134 @@
+"""ABB-Free@Home Device class."""
+
+from typing import Any
+
+from .bin.interface import Interface
+
+
+class Device:
+    """Represents a Free@Home device with all its attributes."""
+
+    def __init__(
+        self,
+        device_serial: str,
+        device_id: str,
+        display_name: str,
+        interface: Interface | None = None,
+        unresponsive: bool = False,
+        unresponsive_counter: int = 0,
+        defect: bool = False,
+        floor: str | None = None,
+        room: str | None = None,
+        floor_name: str | None = None,
+        room_name: str | None = None,
+        device_reboots: str | None = None,
+        native_id: str | None = None,
+        parameters: dict[str, dict[str, Any]] | None = None,
+        channels: dict[str, dict] | None = None,
+    ) -> None:
+        """Initialize the Device class."""
+        self._device_serial = device_serial
+        self._device_id = device_id
+        self._display_name = display_name
+        self._interface = interface if interface is not None else Interface.UNDEFINED
+        self._unresponsive = unresponsive
+        self._unresponsive_counter = unresponsive_counter
+        self._defect = defect
+        self._floor = floor
+        self._room = room
+        self._floor_name = floor_name
+        self._room_name = room_name
+        self._device_reboots = device_reboots
+        self._native_id = native_id
+        self._parameters = parameters or {}
+        self._channels = channels or {}
+
+    @property
+    def device_serial(self) -> str:
+        """Return the device serial."""
+        return self._device_serial
+
+    @property
+    def device_id(self) -> str:
+        """Return the device ID."""
+        return self._device_id
+
+    @property
+    def display_name(self) -> str:
+        """Return the device display name."""
+        return self._display_name
+
+    @property
+    def interface(self) -> Interface:
+        """Return the device interface."""
+        return self._interface
+
+    @property
+    def unresponsive(self) -> bool:
+        """Return True if the device is unresponsive."""
+        return self._unresponsive
+
+    @property
+    def unresponsive_counter(self) -> int:
+        """Return the unresponsive counter."""
+        return self._unresponsive_counter
+
+    @property
+    def defect(self) -> bool:
+        """Return True if the device is defective."""
+        return self._defect
+
+    @property
+    def floor(self) -> str | None:
+        """Return the device floor."""
+        return self._floor
+
+    @property
+    def room(self) -> str | None:
+        """Return the device room."""
+        return self._room
+
+    @property
+    def floor_name(self) -> str | None:
+        """Return the device floor name."""
+        return self._floor_name
+
+    @property
+    def room_name(self) -> str | None:
+        """Return the device room name."""
+        return self._room_name
+
+    @property
+    def device_reboots(self) -> str | None:
+        """Return the device reboot count."""
+        return self._device_reboots
+
+    @property
+    def native_id(self) -> str | None:
+        """Return the device native ID."""
+        return self._native_id
+
+    @property
+    def parameters(self) -> dict[str, Any]:
+        """Return the device parameters."""
+        return self._parameters
+
+    @property
+    def channels(self) -> dict[str, dict]:
+        """Return the device channels."""
+        return self._channels
+
+    @property
+    def is_virtual(self) -> bool:
+        """Return True if this is a virtual device."""
+        return self._interface == Interface.VIRTUAL_DEVICE
+
+    def __repr__(self) -> str:
+        """Return a string representation of the device."""
+        interface_value = self.interface.value if self.interface else None
+        return (
+            f"Device(device_serial='{self.device_serial}', "
+            f"display_name='{self.display_name}', "
+            f"interface='{interface_value}', "
+            f"unresponsive={self.unresponsive})"
+        )

--- a/src/abbfreeathome/device.py
+++ b/src/abbfreeathome/device.py
@@ -125,10 +125,9 @@ class Device:
 
     def __repr__(self) -> str:
         """Return a string representation of the device."""
-        interface_value = self.interface.value if self.interface else None
         return (
             f"Device(device_serial='{self.device_serial}', "
             f"display_name='{self.display_name}', "
-            f"interface='{interface_value}', "
+            f"interface='{self.interface.value}', "
             f"unresponsive={self.unresponsive})"
         )

--- a/src/abbfreeathome/exceptions.py
+++ b/src/abbfreeathome/exceptions.py
@@ -68,11 +68,13 @@ class InvalidApiResponseException(FreeAtHomeException):
 class InvalidDeviceChannelPairing(FreeAtHomeException):
     """Raise an exception for an invalid pairing id."""
 
-    def __init__(self, device_id: str, channel_id: str, pairing_value: int) -> None:
+    def __init__(self, device_serial: str, channel_id: str, pairing_value: int) -> None:
         """Initialze the InvalidDeviceChannelPairing class."""
         self.message = (
             f"Could not find paring id for "
-            f"device: {device_id}; channel: {channel_id}; pairing id: {pairing_value}"
+            f"device: {device_serial}; "
+            f"channel: {channel_id}; "
+            f"pairing id: {pairing_value}"
         )
         super().__init__(self.message)
 
@@ -80,11 +82,13 @@ class InvalidDeviceChannelPairing(FreeAtHomeException):
 class InvalidDeviceChannelParameter(FreeAtHomeException):
     """Raise an exception for an invalid parameter id."""
 
-    def __init__(self, device_id: str, channel_id: str, parameter_value: int) -> None:
+    def __init__(
+        self, device_serial: str, channel_id: str, parameter_value: int
+    ) -> None:
         """Initialze the InvalidDeviceChannelParameter class."""
         self.message = (
             f"Could not find parameter id for "
-            f"device: {device_id}; channel: {channel_id}; "
+            f"device: {device_serial}; channel: {channel_id}; "
             f"parameter id: {parameter_value}"
         )
         super().__init__(self.message)
@@ -102,11 +106,11 @@ class UserNotFoundException(FreeAtHomeException):
 class SetDatapointFailureException(FreeAtHomeException):
     """Raise an exception when setting a datapoint fails."""
 
-    def __init__(self, device_id: str, channel_id: str, datapoint: str, value: str):
+    def __init__(self, device_serial: str, channel_id: str, datapoint: str, value: str):
         """Initialize the SetDatapointFailureException class."""
         self.message = (
-            f"Failed to set datapoint; device_id: "
-            f"{device_id}; "
+            f"Failed to set datapoint; device_serial: "
+            f"{device_serial}; "
             f"channel_id: {channel_id}; "
             f"datapoint: {datapoint}; "
             f"value: {value}"

--- a/src/abbfreeathome/freeathome.py
+++ b/src/abbfreeathome/freeathome.py
@@ -181,7 +181,7 @@ class FreeAtHome:
             )
 
             # Extract device attributes from the configuration
-            device = Device(
+            _device = Device(
                 device_serial=_serial,
                 device_id=_data.get("deviceId", ""),
                 display_name=_data.get("displayName", ""),
@@ -199,7 +199,7 @@ class FreeAtHome:
                 channels=_data.get("channels", {}),
             )
 
-            self._devices[_serial] = device
+            self._devices[_serial] = _device
 
     async def _load_channels(self):
         """Load all of the channels into the channels object."""

--- a/src/abbfreeathome/freeathome.py
+++ b/src/abbfreeathome/freeathome.py
@@ -158,48 +158,48 @@ class FreeAtHome:
     async def _load_devices(self):
         """Load all devices into the devices object."""
         self.clear_devices()
-        config = await self.get_config()
 
-        for device_serial, device_data in config.get("devices", {}).items():
+        _config = await self.get_config()
+        for _serial, _data in _config.get("devices", {}).items():
             # Convert interface string to Interface enum
-            _interface_value = device_data.get("interface")
+            _interface_value = _data.get("interface")
 
             # Any devices that start with "6000" should be considered virtual
-            if device_serial.startswith("6000"):
+            if _serial.startswith("6000"):
                 _interface_value = "VD"
 
-            interface_enum = Interface.from_string(_interface_value)
+            _interface = Interface.from_string(_interface_value)
 
             # Get floor and room names
-            floor_id = device_data.get("floor")
-            room_id = device_data.get("room")
-            floor_name = await self.get_floor_name(floor_id) if floor_id else None
-            room_name = (
-                await self.get_room_name(floor_id, room_id)
-                if floor_id and room_id
+            _floor_id = _data.get("floor")
+            _room_id = _data.get("room")
+            _floor_name = await self.get_floor_name(_floor_id) if _floor_id else None
+            _room_name = (
+                await self.get_room_name(_floor_id, _room_id)
+                if _floor_id and _room_id
                 else None
             )
 
             # Extract device attributes from the configuration
             device = Device(
-                device_serial=device_serial,
-                device_id=device_data.get("deviceId", ""),
-                display_name=device_data.get("displayName", ""),
-                interface=interface_enum,
-                unresponsive=device_data.get("unresponsive", False),
-                unresponsive_counter=device_data.get("unresponsiveCounter", 0),
-                defect=device_data.get("defect", False),
-                floor=floor_id,
-                room=room_id,
-                floor_name=floor_name,
-                room_name=room_name,
-                device_reboots=device_data.get("deviceReboots"),
-                native_id=device_data.get("nativeId"),
-                parameters=device_data.get("parameters", {}),
-                channels=device_data.get("channels", {}),
+                device_serial=_serial,
+                device_id=_data.get("deviceId", ""),
+                display_name=_data.get("displayName", ""),
+                interface=_interface,
+                unresponsive=_data.get("unresponsive", False),
+                unresponsive_counter=_data.get("unresponsiveCounter", 0),
+                defect=_data.get("defect", False),
+                floor=_floor_id,
+                room=_room_id,
+                floor_name=_floor_name,
+                room_name=_room_name,
+                device_reboots=_data.get("deviceReboots"),
+                native_id=_data.get("nativeId"),
+                parameters=_data.get("parameters", {}),
+                channels=_data.get("channels", {}),
             )
 
-            self._devices[device_serial] = device
+            self._devices[_serial] = device
 
     async def _load_channels(self):
         """Load all of the channels into the channels object."""

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -227,7 +227,7 @@ async def test_get_datapoint(api):
     """Test the get_datapoint function."""
     with patch.object(api, "_request", return_value=Mock()) as mock_request:
         mock_request.return_value.get.return_value = {"values": ["value1", "value2"]}
-        datapoint = await api.get_datapoint("device_id", "channel_id", "datapoint")
+        datapoint = await api.get_datapoint("device_serial", "channel_id", "datapoint")
         assert datapoint == ["value1", "value2"]
 
 
@@ -266,7 +266,7 @@ async def test_set_datapoint(api):
     with patch.object(api, "_request", return_value=Mock()) as mock_request:
         mock_request.return_value.get.return_value = {"result": "ok"}
         result = await api.set_datapoint(
-            "device_id", "channel_id", "datapoint", "value"
+            "device_serial", "channel_id", "datapoint", "value"
         )
         assert result is True
 
@@ -295,7 +295,7 @@ async def test_set_datapoint_failure(api):
     with patch.object(api, "_request", return_value=Mock()) as mock_request:
         mock_request.return_value.get.return_value = {"result": "fail"}
         with pytest.raises(SetDatapointFailureException):
-            await api.set_datapoint("device_id", "channel_id", "datapoint", "value")
+            await api.set_datapoint("device_serial", "channel_id", "datapoint", "value")
 
 
 @pytest.mark.asyncio

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -41,7 +41,7 @@ def base_instance(mock_api):
     }
 
     instance = Base(
-        device_id="ABB7F500E17A",
+        device_serial="ABB7F500E17A",
         device_name="Device Name",
         channel_id="ch0003",
         channel_name="Channel Name",
@@ -58,7 +58,7 @@ def base_instance(mock_api):
 
 def test_initialization(base_instance):
     """Test the initialization of the base class."""
-    assert base_instance.device_id == "ABB7F500E17A"
+    assert base_instance.device_serial == "ABB7F500E17A"
     assert base_instance.device_name == "Device Name"
     assert base_instance.channel_id == "ch0003"
     assert base_instance.channel_name == "Channel Name"

--- a/tests/test_blind_sensor.py
+++ b/tests/test_blind_sensor.py
@@ -26,7 +26,7 @@ def blind_sensor(mock_api):
     parameters = {}
 
     return BlindSensor(
-        device_id="ABB700DAD681",
+        device_serial="ABB700DAD681",
         device_name="Device Name",
         channel_id="ch0003",
         channel_name="Channel Name",
@@ -50,7 +50,7 @@ async def test_refresh_state(blind_sensor):
     await blind_sensor.refresh_state()
     assert blind_sensor.state == BlindSensorState.step_down.name
     blind_sensor._api.get_datapoint.assert_called_with(
-        device_id="ABB700DAD681",
+        device_serial="ABB700DAD681",
         channel_id="ch0003",
         datapoint="odp0003",
     )

--- a/tests/test_brightness_sensor.py
+++ b/tests/test_brightness_sensor.py
@@ -18,7 +18,7 @@ def get_brightness_sensor(mock_api):
     parameters = {"par002b": "19998.7", "par002c": "4999.68"}
 
     return BrightnessSensor(
-        device_id="7EB1000021C5",
+        device_serial="7EB1000021C5",
         device_name="Device Name",
         channel_id="ch0000",
         channel_name="Channel Name",
@@ -56,7 +56,7 @@ async def test_refresh_state(brightness_sensor):
     assert brightness_sensor.state == 1.0
     assert brightness_sensor.alarm is True
     brightness_sensor._api.get_datapoint.assert_called_with(
-        device_id="7EB1000021C5",
+        device_serial="7EB1000021C5",
         channel_id="ch0000",
         datapoint="odp0000",
     )

--- a/tests/test_carbon_monoxide_sensor.py
+++ b/tests/test_carbon_monoxide_sensor.py
@@ -25,7 +25,7 @@ def carbon_monoxide_sensor(mock_api):
     parameters = {}
 
     return CarbonMonoxideSensor(
-        device_id="E11253502766",
+        device_serial="E11253502766",
         device_name="Device Name",
         channel_id="ch0000",
         channel_name="Channel Name",
@@ -49,7 +49,7 @@ async def test_refresh_state(carbon_monoxide_sensor):
     await carbon_monoxide_sensor.refresh_state()
     assert carbon_monoxide_sensor.state is True
     carbon_monoxide_sensor._api.get_datapoint.assert_called_with(
-        device_id="E11253502766",
+        device_serial="E11253502766",
         channel_id="ch0000",
         datapoint="odp0000",
     )

--- a/tests/test_cover_actuator.py
+++ b/tests/test_cover_actuator.py
@@ -44,7 +44,7 @@ def cover_actuator(mock_api):
     parameters = {}
 
     return CoverActuator(
-        device_id="ABB2AC253651",
+        device_serial="ABB2AC253651",
         device_name="Device Name",
         channel_id="ch0003",
         channel_name="Channel Name",
@@ -80,7 +80,7 @@ def shutter_actuator(mock_api):
     parameters = {}
 
     return ShutterActuator(
-        device_id="ABB2AC253651",
+        device_serial="ABB2AC253651",
         device_name="Device Name",
         channel_id="ch0003",
         channel_name="Channel Name",
@@ -102,7 +102,7 @@ async def test_open(cover_actuator):
     """Test to open the cover."""
     await cover_actuator.open()
     cover_actuator._api.set_datapoint.assert_called_with(
-        device_id="ABB2AC253651",
+        device_serial="ABB2AC253651",
         channel_id="ch0003",
         datapoint="idp0000",
         value="0",
@@ -114,7 +114,7 @@ async def test_close(cover_actuator):
     """Test to close the cover."""
     await cover_actuator.close()
     cover_actuator._api.set_datapoint.assert_called_with(
-        device_id="ABB2AC253651",
+        device_serial="ABB2AC253651",
         channel_id="ch0003",
         datapoint="idp0000",
         value="1",
@@ -128,7 +128,7 @@ async def test_stop(cover_actuator):
     cover_actuator._state = CoverActuatorState.opening
     await cover_actuator.stop()
     cover_actuator._api.set_datapoint.assert_called_with(
-        device_id="ABB2AC253651",
+        device_serial="ABB2AC253651",
         channel_id="ch0003",
         datapoint="idp0001",
         value="1",
@@ -178,7 +178,7 @@ async def test_set_forced_position(cover_actuator):
         cover_actuator.forced_position == CoverActuatorForcedPosition.deactivated.name
     )
     cover_actuator._api.set_datapoint.assert_called_with(
-        device_id="ABB2AC253651",
+        device_serial="ABB2AC253651",
         channel_id="ch0003",
         datapoint="idp0004",
         value="0",
@@ -191,7 +191,7 @@ async def test_set_forced_position(cover_actuator):
         cover_actuator.forced_position == CoverActuatorForcedPosition.forced_open.name
     )
     cover_actuator._api.set_datapoint.assert_called_with(
-        device_id="ABB2AC253651",
+        device_serial="ABB2AC253651",
         channel_id="ch0003",
         datapoint="idp0004",
         value="2",
@@ -204,7 +204,7 @@ async def test_set_forced_position(cover_actuator):
         cover_actuator.forced_position == CoverActuatorForcedPosition.forced_closed.name
     )
     cover_actuator._api.set_datapoint.assert_called_with(
-        device_id="ABB2AC253651",
+        device_serial="ABB2AC253651",
         channel_id="ch0003",
         datapoint="idp0004",
         value="3",
@@ -219,7 +219,7 @@ async def test_set_position(cover_actuator):
     """Test to set a specific position of the blind."""
     await cover_actuator.set_position(50)
     cover_actuator._api.set_datapoint.assert_called_with(
-        device_id="ABB2AC253651",
+        device_serial="ABB2AC253651",
         channel_id="ch0003",
         datapoint="idp0002",
         value="50",
@@ -229,7 +229,7 @@ async def test_set_position(cover_actuator):
     # Also checking lower and upper boundaries
     await cover_actuator.set_position(-1)
     cover_actuator._api.set_datapoint.assert_called_with(
-        device_id="ABB2AC253651",
+        device_serial="ABB2AC253651",
         channel_id="ch0003",
         datapoint="idp0002",
         value="0",
@@ -237,7 +237,7 @@ async def test_set_position(cover_actuator):
     assert cover_actuator.position == 0
     await cover_actuator.set_position(120)
     cover_actuator._api.set_datapoint.assert_called_with(
-        device_id="ABB2AC253651",
+        device_serial="ABB2AC253651",
         channel_id="ch0003",
         datapoint="idp0002",
         value="100",
@@ -250,7 +250,7 @@ async def test_set_tilt_position(shutter_actuator):
     """Test to set a specific tilt of the shutter."""
     await shutter_actuator.set_tilt_position(50)
     shutter_actuator._api.set_datapoint.assert_called_with(
-        device_id="ABB2AC253651",
+        device_serial="ABB2AC253651",
         channel_id="ch0003",
         datapoint="idp0003",
         value="50",
@@ -260,7 +260,7 @@ async def test_set_tilt_position(shutter_actuator):
     # Also checking lower and upper boundaries
     await shutter_actuator.set_tilt_position(-1)
     shutter_actuator._api.set_datapoint.assert_called_with(
-        device_id="ABB2AC253651",
+        device_serial="ABB2AC253651",
         channel_id="ch0003",
         datapoint="idp0003",
         value="0",
@@ -268,7 +268,7 @@ async def test_set_tilt_position(shutter_actuator):
     assert shutter_actuator.tilt_position == 0
     await shutter_actuator.set_tilt_position(120)
     shutter_actuator._api.set_datapoint.assert_called_with(
-        device_id="ABB2AC253651",
+        device_serial="ABB2AC253651",
         channel_id="ch0003",
         datapoint="idp0003",
         value="100",

--- a/tests/test_des_door_opener_actuator.py
+++ b/tests/test_des_door_opener_actuator.py
@@ -27,7 +27,7 @@ def des_door_opener_actuator(mock_api):
     parameters = {}
 
     return DesDoorOpenerActuator(
-        device_id="0007EE9503A4",
+        device_serial="0007EE9503A4",
         device_name="Device Name",
         channel_id="ch0040",
         channel_name="Channel Name",
@@ -50,7 +50,7 @@ async def test_lock(des_door_opener_actuator):
     await des_door_opener_actuator.lock()
     assert des_door_opener_actuator.state is False
     des_door_opener_actuator._api.set_datapoint.assert_called_with(
-        device_id="0007EE9503A4",
+        device_serial="0007EE9503A4",
         channel_id="ch0040",
         datapoint="idp0000",
         value="0",
@@ -63,7 +63,7 @@ async def test_unlock(des_door_opener_actuator):
     await des_door_opener_actuator.unlock()
     assert des_door_opener_actuator.state is True
     des_door_opener_actuator._api.set_datapoint.assert_called_with(
-        device_id="0007EE9503A4",
+        device_serial="0007EE9503A4",
         channel_id="ch0040",
         datapoint="idp0000",
         value="1",
@@ -77,7 +77,7 @@ async def test_refresh_state(des_door_opener_actuator):
     await des_door_opener_actuator.refresh_state()
     assert des_door_opener_actuator.state is True
     des_door_opener_actuator._api.get_datapoint.assert_called_with(
-        device_id="0007EE9503A4",
+        device_serial="0007EE9503A4",
         channel_id="ch0040",
         datapoint="odp0000",
     )

--- a/tests/test_des_door_ringing_sensor.py
+++ b/tests/test_des_door_ringing_sensor.py
@@ -25,7 +25,7 @@ def des_door_ringing_sensor(mock_api):
     parameters = {}
 
     return DesDoorRingingSensor(
-        device_id="0007EE9503A4",
+        device_serial="0007EE9503A4",
         device_name="Device Name",
         channel_id="ch0000",
         channel_name="Channel Name",

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -1,0 +1,314 @@
+"""Test code for the Device class."""
+
+from src.abbfreeathome.bin.interface import Interface
+from src.abbfreeathome.device import Device
+
+
+def test_device_initialization_minimal():
+    """Test Device initialization with minimal parameters."""
+    device = Device(
+        device_serial="ABB7F500E17A", device_id="910C", display_name="Test Device"
+    )
+
+    assert device.device_serial == "ABB7F500E17A"
+    assert device.device_id == "910C"
+    assert device.display_name == "Test Device"
+    assert device.interface == Interface.UNDEFINED
+    assert device.unresponsive is False
+    assert device.unresponsive_counter == 0
+    assert device.defect is False
+    assert device.floor is None
+    assert device.room is None
+    assert device.floor_name is None
+    assert device.room_name is None
+    assert device.device_reboots is None
+    assert device.native_id is None
+    assert device.parameters == {}
+    assert device.channels == {}
+    assert device.is_virtual is False
+
+
+def test_device_initialization_full():
+    """Test Device initialization with all parameters."""
+    test_parameters = {"par0001": "value1", "par0002": "value2"}
+    test_channels = {
+        "ch0000": {"displayName": "Channel 1"},
+        "ch0001": {"displayName": "Channel 2"},
+    }
+
+    device = Device(
+        device_serial="ABB7F500E17A",
+        device_id="910C",
+        display_name="Test Device",
+        interface=Interface.WIRED_BUS,
+        unresponsive=True,
+        unresponsive_counter=5,
+        defect=True,
+        floor="01",
+        room="02",
+        floor_name="Ground Floor",
+        room_name="Living Room",
+        device_reboots="10",
+        native_id="NATIVE123",
+        parameters=test_parameters,
+        channels=test_channels,
+    )
+
+    assert device.device_serial == "ABB7F500E17A"
+    assert device.device_id == "910C"
+    assert device.display_name == "Test Device"
+    assert device.interface == Interface.WIRED_BUS
+    assert device.unresponsive is True
+    assert device.unresponsive_counter == 5
+    assert device.defect is True
+    assert device.floor == "01"
+    assert device.room == "02"
+    assert device.floor_name == "Ground Floor"
+    assert device.room_name == "Living Room"
+    assert device.device_reboots == "10"
+    assert device.native_id == "NATIVE123"
+    assert device.parameters == test_parameters
+    assert device.channels == test_channels
+    assert device.is_virtual is False
+
+
+def test_device_virtual_detection():
+    """Test virtual device detection based on device serial."""
+    # Test virtual device (starts with 6000)
+    virtual_device = Device(
+        device_serial="6000F91624D1",
+        device_id="0161",
+        display_name="Virtual Device",
+        interface=Interface.VIRTUAL_DEVICE,
+    )
+    assert virtual_device.is_virtual is True
+
+    # Test non-virtual device (doesn't start with 6000)
+    physical_device = Device(
+        device_serial="ABB7F500E17A", device_id="910C", display_name="Physical Device"
+    )
+    assert physical_device.is_virtual is False
+
+
+def test_device_interface_enum():
+    """Test device interface with different Interface enum values."""
+    test_cases = [
+        (Interface.WIRED_BUS, "TP"),
+        (Interface.WIRELESS_RF, "RF"),
+        (Interface.HUE, "hue"),
+        (Interface.SONOS, "sonos"),
+        (Interface.VIRTUAL_DEVICE, "VD"),
+        (Interface.SMOKEALARM, "smokealarm"),
+        (Interface.UNDEFINED, None),
+    ]
+
+    for interface_enum, expected_value in test_cases:
+        device = Device(
+            device_serial="TEST123",
+            device_id="TEST",
+            display_name="Test Device",
+            interface=interface_enum,
+        )
+        assert device.interface == interface_enum
+        assert device.interface.value == expected_value
+
+
+def test_device_parameters_default():
+    """Test device parameters default to empty dict when None."""
+    device = Device(
+        device_serial="TEST123",
+        device_id="TEST",
+        display_name="Test Device",
+        parameters=None,
+    )
+    assert device.parameters == {}
+
+
+def test_device_channels_default():
+    """Test device channels default to empty dict when None."""
+    device = Device(
+        device_serial="TEST123",
+        device_id="TEST",
+        display_name="Test Device",
+        channels=None,
+    )
+    assert device.channels == {}
+
+
+def test_device_repr():
+    """Test device string representation."""
+    # Test with interface enum
+    device = Device(
+        device_serial="ABB7F500E17A",
+        device_id="910C",
+        display_name="Test Device",
+        interface=Interface.WIRED_BUS,
+        unresponsive=True,
+    )
+
+    repr_str = repr(device)
+    assert "device_serial='ABB7F500E17A'" in repr_str
+    assert "display_name='Test Device'" in repr_str
+    assert "interface='TP'" in repr_str
+    assert "unresponsive=True" in repr_str
+
+
+def test_device_repr_no_interface():
+    """Test device string representation with no interface."""
+    device = Device(
+        device_serial="ABB7F500E17A",
+        device_id="910C",
+        display_name="Test Device",
+        interface=None,
+        unresponsive=False,
+    )
+
+    repr_str = repr(device)
+    assert "device_serial='ABB7F500E17A'" in repr_str
+    assert "display_name='Test Device'" in repr_str
+    assert "interface='None'" in repr_str
+    assert "unresponsive=False" in repr_str
+
+
+def test_device_repr_undefined_interface():
+    """Test device string representation with undefined interface."""
+    device = Device(
+        device_serial="ABB7F500E17A",
+        device_id="910C",
+        display_name="Test Device",
+        interface=Interface.UNDEFINED,
+        unresponsive=False,
+    )
+
+    repr_str = repr(device)
+    assert "device_serial='ABB7F500E17A'" in repr_str
+    assert "display_name='Test Device'" in repr_str
+    assert "interface='None'" in repr_str
+    assert "unresponsive=False" in repr_str
+
+
+def test_device_all_properties():
+    """Test all device properties are accessible."""
+    test_parameters = {"par0001": "value1"}
+    test_channels = {"ch0000": {"displayName": "Channel 1"}}
+
+    device = Device(
+        device_serial="ABB7F500E17A",
+        device_id="910C",
+        display_name="Test Device",
+        interface=Interface.HUE,
+        unresponsive=True,
+        unresponsive_counter=3,
+        defect=False,
+        floor="02",
+        room="05",
+        floor_name="First Floor",
+        room_name="Bedroom",
+        device_reboots="15",
+        native_id="NATIVE456",
+        parameters=test_parameters,
+        channels=test_channels,
+    )
+
+    # Test all properties are accessible and return correct values
+    assert device.device_serial == "ABB7F500E17A"
+    assert device.device_id == "910C"
+    assert device.display_name == "Test Device"
+    assert device.interface == Interface.HUE
+    assert device.unresponsive is True
+    assert device.unresponsive_counter == 3
+    assert device.defect is False
+    assert device.floor == "02"
+    assert device.room == "05"
+    assert device.floor_name == "First Floor"
+    assert device.room_name == "Bedroom"
+    assert device.device_reboots == "15"
+    assert device.native_id == "NATIVE456"
+    assert device.parameters is test_parameters
+    assert device.channels is test_channels
+    assert device.is_virtual is False
+
+
+def test_device_empty_strings():
+    """Test device with empty string values."""
+    device = Device(
+        device_serial="",
+        device_id="",
+        display_name="",
+        floor="",
+        room="",
+        device_reboots="",
+        native_id="",
+    )
+
+    assert device.device_serial == ""
+    assert device.device_id == ""
+    assert device.display_name == ""
+    assert device.floor == ""
+    assert device.room == ""
+    assert device.device_reboots == ""
+    assert device.native_id == ""
+    assert device.is_virtual is False  # Empty string doesn't start with "6000"
+
+
+def test_device_interface_conversion():
+    """Test interface conversion for different interface values."""
+    # Test that the device properly handles Interface enum values
+    interfaces_to_test = [
+        Interface.UNDEFINED,
+        Interface.WIRED_BUS,
+        Interface.WIRELESS_RF,
+        Interface.HUE,
+        Interface.SONOS,
+        Interface.VIRTUAL_DEVICE,
+        Interface.SMOKEALARM,
+    ]
+
+    for interface in interfaces_to_test:
+        device = Device(
+            device_serial="TEST123",
+            device_id="TEST",
+            display_name="Test Device",
+            interface=interface,
+        )
+        assert device.interface == interface
+
+        # Test repr handles the interface correctly
+        repr_str = repr(device)
+        expected_value = interface.value if interface.value is not None else "None"
+        assert f"interface='{expected_value}'" in repr_str
+
+
+def test_device_floor_room_names_properties():
+    """Test floor_name and room_name properties specifically."""
+    # Test with both floor and room names
+    device_with_names = Device(
+        device_serial="TEST123",
+        device_id="TEST",
+        display_name="Test Device",
+        floor="01",
+        room="02",
+        floor_name="Ground Floor",
+        room_name="Living Room",
+    )
+
+    assert device_with_names.floor == "01"
+    assert device_with_names.room == "02"
+    assert device_with_names.floor_name == "Ground Floor"
+    assert device_with_names.room_name == "Living Room"
+
+    # Test with None values
+    device_no_names = Device(
+        device_serial="TEST456",
+        device_id="TEST",
+        display_name="Test Device",
+        floor=None,
+        room=None,
+        floor_name=None,
+        room_name=None,
+    )
+
+    assert device_no_names.floor is None
+    assert device_no_names.room is None
+    assert device_no_names.floor_name is None
+    assert device_no_names.room_name is None

--- a/tests/test_dimming_actuator.py
+++ b/tests/test_dimming_actuator.py
@@ -35,7 +35,7 @@ def dimming_actuator(mock_api):
     parameters = {}
 
     return DimmingActuator(
-        device_id="ABB70139AF8A",
+        device_serial="ABB70139AF8A",
         device_name="Device Name",
         channel_id="ch0000",
         channel_name="Channel Name",
@@ -68,7 +68,7 @@ def colortemperature_actuator(mock_api):
     }
 
     return ColorTemperatureActuator(
-        device_id="ABB7026310B7",
+        device_serial="ABB7026310B7",
         device_name="Device Name",
         channel_id="ch0000",
         channel_name="Channel Name",
@@ -91,7 +91,7 @@ async def test_turn_on(dimming_actuator):
     await dimming_actuator.turn_on()
     assert dimming_actuator.state is True
     dimming_actuator._api.set_datapoint.assert_called_with(
-        device_id="ABB70139AF8A",
+        device_serial="ABB70139AF8A",
         channel_id="ch0000",
         datapoint="idp0000",
         value="1",
@@ -104,7 +104,7 @@ async def test_turn_off(dimming_actuator):
     await dimming_actuator.turn_off()
     assert dimming_actuator.state is False
     dimming_actuator._api.set_datapoint.assert_called_with(
-        device_id="ABB70139AF8A",
+        device_serial="ABB70139AF8A",
         channel_id="ch0000",
         datapoint="idp0000",
         value="0",
@@ -133,7 +133,7 @@ async def test_set_forced(dimming_actuator):
         == DimmingActuatorForcedPosition.deactivated.name
     )
     dimming_actuator._api.set_datapoint.assert_called_with(
-        device_id="ABB70139AF8A",
+        device_serial="ABB70139AF8A",
         channel_id="ch0000",
         datapoint="idp0004",
         value="0",
@@ -146,7 +146,7 @@ async def test_set_forced(dimming_actuator):
         == DimmingActuatorForcedPosition.forced_off.name
     )
     dimming_actuator._api.set_datapoint.assert_called_with(
-        device_id="ABB70139AF8A",
+        device_serial="ABB70139AF8A",
         channel_id="ch0000",
         datapoint="idp0004",
         value="2",
@@ -158,7 +158,7 @@ async def test_set_forced(dimming_actuator):
         dimming_actuator.forced_position == DimmingActuatorForcedPosition.forced_on.name
     )
     dimming_actuator._api.set_datapoint.assert_called_with(
-        device_id="ABB70139AF8A",
+        device_serial="ABB70139AF8A",
         channel_id="ch0000",
         datapoint="idp0004",
         value="3",
@@ -177,7 +177,7 @@ async def test_refresh_state(dimming_actuator):
     await dimming_actuator.refresh_state()
     assert dimming_actuator.state is True
     dimming_actuator._api.get_datapoint.assert_called_with(
-        device_id="ABB70139AF8A",
+        device_serial="ABB70139AF8A",
         channel_id="ch0000",
         datapoint="odp0001",
     )

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -82,7 +82,10 @@ def test_set_datapoint_failure_exception():
         )
     assert str(excinfo.value) == (
         "Failed to set datapoint; "
-        "device_id: device1; channel_id: channel1; datapoint: datapoint1; value: value1"
+        "device_serial: device1; "
+        "channel_id: channel1; "
+        "datapoint: datapoint1; "
+        "value: value1"
     )
 
 

--- a/tests/test_force_on_off_sensor.py
+++ b/tests/test_force_on_off_sensor.py
@@ -28,7 +28,7 @@ def force_on_off_sensor(mock_api):
     parameters = {}
 
     return ForceOnOffSensor(
-        device_id="ABB7F5923D74",
+        device_serial="ABB7F5923D74",
         device_name="Device Name",
         channel_id="ch0000",
         channel_name="Channel Name",
@@ -52,7 +52,7 @@ async def test_refresh_state(force_on_off_sensor):
     await force_on_off_sensor.refresh_state()
     assert force_on_off_sensor.state == ForceOnOffSensorState.off.name
     force_on_off_sensor._api.get_datapoint.assert_called_with(
-        device_id="ABB7F5923D74",
+        device_serial="ABB7F5923D74",
         channel_id="ch0000",
         datapoint="odp0005",
     )

--- a/tests/test_heating_actuator.py
+++ b/tests/test_heating_actuator.py
@@ -27,7 +27,7 @@ def heating_actuator(mock_api):
     parameters = {}
 
     return HeatingActuator(
-        device_id="ABB289613651",
+        device_serial="ABB289613651",
         device_name="Device Name",
         channel_id="ch0002",
         channel_name="Channel Name",
@@ -49,7 +49,7 @@ async def test_set_position(heating_actuator):
     """Test to set a specific position of the HeatingActuator."""
     await heating_actuator.set_position(50)
     heating_actuator._api.set_datapoint.assert_called_with(
-        device_id="ABB289613651",
+        device_serial="ABB289613651",
         channel_id="ch0002",
         datapoint="idp0000",
         value="50",
@@ -59,7 +59,7 @@ async def test_set_position(heating_actuator):
     # Also checking lower and upper boundaries
     await heating_actuator.set_position(-1)
     heating_actuator._api.set_datapoint.assert_called_with(
-        device_id="ABB289613651",
+        device_serial="ABB289613651",
         channel_id="ch0002",
         datapoint="idp0000",
         value="0",
@@ -67,7 +67,7 @@ async def test_set_position(heating_actuator):
     assert heating_actuator.position == 0
     await heating_actuator.set_position(120)
     heating_actuator._api.set_datapoint.assert_called_with(
-        device_id="ABB289613651",
+        device_serial="ABB289613651",
         channel_id="ch0002",
         datapoint="idp0000",
         value="100",

--- a/tests/test_movement_detector.py
+++ b/tests/test_movement_detector.py
@@ -23,7 +23,7 @@ def get_movement_detector(type: str, mock_api):
         outputs.pop("odp0002")
 
     return MovementDetector(
-        device_id="ABB7F500E17A",
+        device_serial="ABB7F500E17A",
         device_name="Device Name",
         channel_id="ch0003",
         channel_name="Channel Name",
@@ -74,7 +74,7 @@ async def test_refresh_state(movement_detector_indoor):
     assert movement_detector_indoor.state is True
     assert movement_detector_indoor.brightness == 1.0
     movement_detector_indoor._api.get_datapoint.assert_called_with(
-        device_id="ABB7F500E17A",
+        device_serial="ABB7F500E17A",
         channel_id="ch0003",
         datapoint="odp0000",
     )

--- a/tests/test_rain_sensor.py
+++ b/tests/test_rain_sensor.py
@@ -20,7 +20,7 @@ def get_rain_sensor(mock_api):
     parameters = {"par0049": "1", "par0047": "2", "par0048": "7"}
 
     return RainSensor(
-        device_id="7EB1000021C5",
+        device_serial="7EB1000021C5",
         device_name="Device Name",
         channel_id="ch0001",
         channel_name="Channel Name",
@@ -56,7 +56,7 @@ async def test_refresh_state(rain_sensor):
     await rain_sensor.refresh_state()
     assert rain_sensor.state is True
     rain_sensor._api.get_datapoint.assert_called_with(
-        device_id="7EB1000021C5",
+        device_serial="7EB1000021C5",
         channel_id="ch0001",
         datapoint="odp0000",
     )

--- a/tests/test_room_temperature_controller.py
+++ b/tests/test_room_temperature_controller.py
@@ -36,7 +36,7 @@ def room_temperature_controller(mock_api):
     parameters = {}
 
     return RoomTemperatureController(
-        device_id="ABB700D72CC9",
+        device_serial="ABB700D72CC9",
         device_name="Device Name",
         channel_id="ch0000",
         channel_name="Channel Name",
@@ -59,7 +59,7 @@ async def test_turn_on(room_temperature_controller):
     await room_temperature_controller.turn_on()
     assert room_temperature_controller.state is True
     room_temperature_controller._api.set_datapoint.assert_called_with(
-        device_id="ABB700D72CC9",
+        device_serial="ABB700D72CC9",
         channel_id="ch0000",
         datapoint="idp0012",
         value="1",
@@ -72,7 +72,7 @@ async def test_turn_off(room_temperature_controller):
     await room_temperature_controller.turn_off()
     assert room_temperature_controller.state is False
     room_temperature_controller._api.set_datapoint.assert_called_with(
-        device_id="ABB700D72CC9",
+        device_serial="ABB700D72CC9",
         channel_id="ch0000",
         datapoint="idp0012",
         value="0",
@@ -85,7 +85,7 @@ async def test_eco_on(room_temperature_controller):
     await room_temperature_controller.eco_on()
     assert room_temperature_controller.eco_mode is True
     room_temperature_controller._api.set_datapoint.assert_called_with(
-        device_id="ABB700D72CC9",
+        device_serial="ABB700D72CC9",
         channel_id="ch0000",
         datapoint="idp0011",
         value="1",
@@ -98,7 +98,7 @@ async def test_eco_off(room_temperature_controller):
     await room_temperature_controller.eco_off()
     assert room_temperature_controller.eco_mode is False
     room_temperature_controller._api.set_datapoint.assert_called_with(
-        device_id="ABB700D72CC9",
+        device_serial="ABB700D72CC9",
         channel_id="ch0000",
         datapoint="idp0011",
         value="0",
@@ -111,18 +111,27 @@ async def test_set_temperature(room_temperature_controller):
     await room_temperature_controller.set_temperature(30)
     assert room_temperature_controller.target_temperature == 30
     room_temperature_controller._api.set_datapoint.assert_called_with(
-        device_id="ABB700D72CC9", channel_id="ch0000", datapoint="idp0016", value="30"
+        device_serial="ABB700D72CC9",
+        channel_id="ch0000",
+        datapoint="idp0016",
+        value="30",
     )
     # Also checking lower and upper boundaries
     await room_temperature_controller.set_temperature(0)
     assert room_temperature_controller.target_temperature == 7
     room_temperature_controller._api.set_datapoint.assert_called_with(
-        device_id="ABB700D72CC9", channel_id="ch0000", datapoint="idp0016", value="7"
+        device_serial="ABB700D72CC9",
+        channel_id="ch0000",
+        datapoint="idp0016",
+        value="7",
     )
     await room_temperature_controller.set_temperature(50)
     assert room_temperature_controller.target_temperature == 35
     room_temperature_controller._api.set_datapoint.assert_called_with(
-        device_id="ABB700D72CC9", channel_id="ch0000", datapoint="idp0016", value="35"
+        device_serial="ABB700D72CC9",
+        channel_id="ch0000",
+        datapoint="idp0016",
+        value="35",
     )
 
 
@@ -133,7 +142,7 @@ async def test_refresh_state(room_temperature_controller):
     await room_temperature_controller.refresh_state()
     assert room_temperature_controller.state is True
     room_temperature_controller._api.get_datapoint.assert_called_with(
-        device_id="ABB700D72CC9",
+        device_serial="ABB700D72CC9",
         channel_id="ch0000",
         datapoint="odp0008",
     )

--- a/tests/test_smoke_detector.py
+++ b/tests/test_smoke_detector.py
@@ -25,7 +25,7 @@ def smoke_detector(mock_api):
     parameters = {}
 
     return SmokeDetector(
-        device_id="E11244221190",
+        device_serial="E11244221190",
         device_name="Device Name",
         channel_id="ch0000",
         channel_name="Channel Name",
@@ -49,7 +49,7 @@ async def test_refresh_state(smoke_detector):
     await smoke_detector.refresh_state()
     assert smoke_detector.state is True
     smoke_detector._api.get_datapoint.assert_called_with(
-        device_id="E11244221190",
+        device_serial="E11244221190",
         channel_id="ch0000",
         datapoint="odp0000",
     )

--- a/tests/test_switch_actuator.py
+++ b/tests/test_switch_actuator.py
@@ -35,7 +35,7 @@ def switch_actuator(mock_api):
     parameters = {}
 
     return SwitchActuator(
-        device_id="ABB7F500E17A",
+        device_serial="ABB7F500E17A",
         device_name="Device Name",
         channel_id="ch0003",
         channel_name="Channel Name",
@@ -58,7 +58,7 @@ async def test_turn_on(switch_actuator):
     await switch_actuator.turn_on()
     assert switch_actuator.state is True
     switch_actuator._api.set_datapoint.assert_called_with(
-        device_id="ABB7F500E17A",
+        device_serial="ABB7F500E17A",
         channel_id="ch0003",
         datapoint="idp0000",
         value="1",
@@ -71,7 +71,7 @@ async def test_turn_off(switch_actuator):
     await switch_actuator.turn_off()
     assert switch_actuator.state is False
     switch_actuator._api.set_datapoint.assert_called_with(
-        device_id="ABB7F500E17A",
+        device_serial="ABB7F500E17A",
         channel_id="ch0003",
         datapoint="idp0000",
         value="0",
@@ -88,7 +88,7 @@ async def test_set_forced(switch_actuator):
         switch_actuator.forced_position == SwitchActuatorForcedPosition.deactivated.name
     )
     switch_actuator._api.set_datapoint.assert_called_with(
-        device_id="ABB7F500E17A",
+        device_serial="ABB7F500E17A",
         channel_id="ch0003",
         datapoint="idp0002",
         value="0",
@@ -100,7 +100,7 @@ async def test_set_forced(switch_actuator):
         switch_actuator.forced_position == SwitchActuatorForcedPosition.forced_off.name
     )
     switch_actuator._api.set_datapoint.assert_called_with(
-        device_id="ABB7F500E17A",
+        device_serial="ABB7F500E17A",
         channel_id="ch0003",
         datapoint="idp0002",
         value="2",
@@ -112,7 +112,7 @@ async def test_set_forced(switch_actuator):
         switch_actuator.forced_position == SwitchActuatorForcedPosition.forced_on.name
     )
     switch_actuator._api.set_datapoint.assert_called_with(
-        device_id="ABB7F500E17A",
+        device_serial="ABB7F500E17A",
         channel_id="ch0003",
         datapoint="idp0002",
         value="3",
@@ -129,7 +129,7 @@ async def test_refresh_state(switch_actuator):
     await switch_actuator.refresh_state()
     assert switch_actuator.state is True
     switch_actuator._api.get_datapoint.assert_called_with(
-        device_id="ABB7F500E17A",
+        device_serial="ABB7F500E17A",
         channel_id="ch0003",
         datapoint="odp0000",
     )

--- a/tests/test_switch_sensor.py
+++ b/tests/test_switch_sensor.py
@@ -35,7 +35,7 @@ def switch_sensor_with_led(mock_api):
     }
 
     return SwitchSensor(
-        device_id="ABB700D9C0A4",
+        device_serial="ABB700D9C0A4",
         device_name="Device Name",
         channel_id="ch0000",
         channel_name="Channel Name",
@@ -62,7 +62,7 @@ def switch_sensor_without_led(mock_api):
     }
 
     return SwitchSensor(
-        device_id="ABB700D9C0A4",
+        device_serial="ABB700D9C0A4",
         device_name="Device Name",
         channel_id="ch0000",
         channel_name="Channel Name",
@@ -85,7 +85,7 @@ def dimming_sensor(mock_api):
     parameters = {}
 
     return DimmingSensor(
-        device_id="ABB700D9C0A4",
+        device_serial="ABB700D9C0A4",
         device_name="Device Name",
         channel_id="ch0000",
         channel_name="Channel Name",
@@ -108,7 +108,7 @@ async def test_turn_on_led(switch_sensor_with_led):
     await switch_sensor_with_led.turn_on_led()
     assert switch_sensor_with_led.led is True
     switch_sensor_with_led._api.set_datapoint.assert_called_with(
-        device_id="ABB700D9C0A4",
+        device_serial="ABB700D9C0A4",
         channel_id="ch0000",
         datapoint="idp0000",
         value="1",
@@ -121,7 +121,7 @@ async def test_turn_off_led(switch_sensor_with_led):
     await switch_sensor_with_led.turn_off_led()
     assert switch_sensor_with_led.led is False
     switch_sensor_with_led._api.set_datapoint.assert_called_with(
-        device_id="ABB700D9C0A4",
+        device_serial="ABB700D9C0A4",
         channel_id="ch0000",
         datapoint="idp0000",
         value="0",
@@ -135,7 +135,7 @@ async def test_refresh_state_with_led(switch_sensor_with_led):
     await switch_sensor_with_led.refresh_state()
     assert switch_sensor_with_led.led is True
     switch_sensor_with_led._api.get_datapoint.assert_called_with(
-        device_id="ABB700D9C0A4",
+        device_serial="ABB700D9C0A4",
         channel_id="ch0000",
         datapoint="idp0000",
     )
@@ -148,7 +148,7 @@ async def test_refresh_state_without_led(switch_sensor_without_led):
     await switch_sensor_without_led.refresh_state()
     assert switch_sensor_without_led.led is None
     switch_sensor_without_led._api.get_datapoint.assert_called_with(
-        device_id="ABB700D9C0A4",
+        device_serial="ABB700D9C0A4",
         channel_id="ch0000",
         datapoint="idp0000",
     )

--- a/tests/test_temperature_sensor.py
+++ b/tests/test_temperature_sensor.py
@@ -19,7 +19,7 @@ def get_temperature_sensor(mock_api):
     parameters = {"par002d": "4", "par0047": "7", "par0048": "7"}
 
     return TemperatureSensor(
-        device_id="7EB1000021C5",
+        device_serial="7EB1000021C5",
         device_name="Device Name",
         channel_id="ch0002",
         channel_name="Channel Name",
@@ -57,7 +57,7 @@ async def test_refresh_state(temperature_sensor):
     assert temperature_sensor.state == 1.0
     assert temperature_sensor.alarm is True
     temperature_sensor._api.get_datapoint.assert_called_with(
-        device_id="7EB1000021C5",
+        device_serial="7EB1000021C5",
         channel_id="ch0002",
         datapoint="odp0000",
     )

--- a/tests/test_trigger.py
+++ b/tests/test_trigger.py
@@ -25,7 +25,7 @@ def trigger(mock_api):
     parameters = {}
 
     return Trigger(
-        device_id="ABB28EBC3651",
+        device_serial="ABB28EBC3651",
         device_name="Device Name",
         channel_id="ch0003",
         channel_name="Channel Name",
@@ -41,7 +41,7 @@ async def test_press(trigger):
     """Test to press the trigger."""
     await trigger.press()
     trigger._api.set_datapoint.assert_called_with(
-        device_id="ABB28EBC3651",
+        device_serial="ABB28EBC3651",
         channel_id="ch0003",
         datapoint="idp0001",
         value="1",

--- a/tests/test_virtual_brightness_sensor.py
+++ b/tests/test_virtual_brightness_sensor.py
@@ -28,7 +28,7 @@ def virtual_brightness_sensor(mock_api):
     parameters = {}
 
     return VirtualBrightnessSensor(
-        device_id="6000A0EA2CF4",
+        device_serial="6000A0EA2CF4",
         device_name="Device Name",
         channel_id="ch0000",
         channel_name="Channel Name",
@@ -44,7 +44,7 @@ async def test_turn_on(virtual_brightness_sensor):
     """Test to activate the sensor."""
     await virtual_brightness_sensor.turn_on()
     virtual_brightness_sensor._api.set_datapoint.assert_called_with(
-        device_id="6000A0EA2CF4",
+        device_serial="6000A0EA2CF4",
         channel_id="ch0000",
         datapoint="odp0000",
         value="1",
@@ -57,7 +57,7 @@ async def test_turn_off(virtual_brightness_sensor):
     """Test to deactivate the sensor."""
     await virtual_brightness_sensor.turn_off()
     virtual_brightness_sensor._api.set_datapoint.assert_called_with(
-        device_id="6000A0EA2CF4",
+        device_serial="6000A0EA2CF4",
         channel_id="ch0000",
         datapoint="odp0000",
         value="0",
@@ -71,7 +71,7 @@ async def test_set_brightness(virtual_brightness_sensor):
     """Values greather 0 should always work"""
     await virtual_brightness_sensor.set_brightness(25)
     virtual_brightness_sensor._api.set_datapoint.assert_called_with(
-        device_id="6000A0EA2CF4",
+        device_serial="6000A0EA2CF4",
         channel_id="ch0000",
         datapoint="odp0001",
         value="25",
@@ -81,7 +81,7 @@ async def test_set_brightness(virtual_brightness_sensor):
     """Float values should return integer"""
     await virtual_brightness_sensor.set_brightness(13.7)
     virtual_brightness_sensor._api.set_datapoint.assert_called_with(
-        device_id="6000A0EA2CF4",
+        device_serial="6000A0EA2CF4",
         channel_id="ch0000",
         datapoint="odp0001",
         value="13",
@@ -91,7 +91,7 @@ async def test_set_brightness(virtual_brightness_sensor):
     """Negative values should return 0"""
     await virtual_brightness_sensor.set_brightness(-3.4)
     virtual_brightness_sensor._api.set_datapoint.assert_called_with(
-        device_id="6000A0EA2CF4",
+        device_serial="6000A0EA2CF4",
         channel_id="ch0000",
         datapoint="odp0001",
         value="0",

--- a/tests/test_virtual_energy_battery.py
+++ b/tests/test_virtual_energy_battery.py
@@ -32,7 +32,7 @@ def virtual_energy_battery(mock_api):
     parameters = {}
 
     return VirtualEnergyBattery(
-        device_id="6000702DC087",
+        device_serial="6000702DC087",
         device_name="Device Name",
         channel_id="ch0002",
         channel_name="Channel Name",
@@ -48,7 +48,7 @@ async def test_set_battery_power(virtual_energy_battery):
     """Test to set battery_power of the sensor."""
     await virtual_energy_battery.set_battery_power(435.7)
     virtual_energy_battery._api.set_datapoint.assert_called_with(
-        device_id="6000702DC087",
+        device_serial="6000702DC087",
         channel_id="ch0002",
         datapoint="odp0000",
         value="435.7",
@@ -62,7 +62,7 @@ async def test_set_soc(virtual_energy_battery):
     """between 0 and 100 is ok"""
     await virtual_energy_battery.set_soc(55)
     virtual_energy_battery._api.set_datapoint.assert_called_with(
-        device_id="6000702DC087",
+        device_serial="6000702DC087",
         channel_id="ch0002",
         datapoint="odp0001",
         value="55",
@@ -72,7 +72,7 @@ async def test_set_soc(virtual_energy_battery):
     """Float values should return integer"""
     await virtual_energy_battery.set_soc(5.5)
     virtual_energy_battery._api.set_datapoint.assert_called_with(
-        device_id="6000702DC087",
+        device_serial="6000702DC087",
         channel_id="ch0002",
         datapoint="odp0001",
         value="5",
@@ -82,7 +82,7 @@ async def test_set_soc(virtual_energy_battery):
     """Below 0 is always 0"""
     await virtual_energy_battery.set_soc(-7.5)
     virtual_energy_battery._api.set_datapoint.assert_called_with(
-        device_id="6000702DC087",
+        device_serial="6000702DC087",
         channel_id="ch0002",
         datapoint="odp0001",
         value="0",
@@ -92,7 +92,7 @@ async def test_set_soc(virtual_energy_battery):
     """Above 100 is always 100"""
     await virtual_energy_battery.set_soc(150)
     virtual_energy_battery._api.set_datapoint.assert_called_with(
-        device_id="6000702DC087",
+        device_serial="6000702DC087",
         channel_id="ch0002",
         datapoint="odp0001",
         value="100",
@@ -106,7 +106,7 @@ async def test_set_imported_today(virtual_energy_battery):
     """Values greater 0 should always work"""
     await virtual_energy_battery.set_imported_today(25)
     virtual_energy_battery._api.set_datapoint.assert_called_with(
-        device_id="6000702DC087",
+        device_serial="6000702DC087",
         channel_id="ch0002",
         datapoint="odp0002",
         value="25",
@@ -116,7 +116,7 @@ async def test_set_imported_today(virtual_energy_battery):
     """Float values should return integer"""
     await virtual_energy_battery.set_imported_today(13.7)
     virtual_energy_battery._api.set_datapoint.assert_called_with(
-        device_id="6000702DC087",
+        device_serial="6000702DC087",
         channel_id="ch0002",
         datapoint="odp0002",
         value="13",
@@ -126,7 +126,7 @@ async def test_set_imported_today(virtual_energy_battery):
     """Negative values should return 0"""
     await virtual_energy_battery.set_imported_today(-3.4)
     virtual_energy_battery._api.set_datapoint.assert_called_with(
-        device_id="6000702DC087",
+        device_serial="6000702DC087",
         channel_id="ch0002",
         datapoint="odp0002",
         value="0",
@@ -140,7 +140,7 @@ async def test_set_exported_today(virtual_energy_battery):
     """Values greater 0 should always work"""
     await virtual_energy_battery.set_exported_today(25)
     virtual_energy_battery._api.set_datapoint.assert_called_with(
-        device_id="6000702DC087",
+        device_serial="6000702DC087",
         channel_id="ch0002",
         datapoint="odp0003",
         value="25",
@@ -150,7 +150,7 @@ async def test_set_exported_today(virtual_energy_battery):
     """Float values should return integer"""
     await virtual_energy_battery.set_exported_today(13.7)
     virtual_energy_battery._api.set_datapoint.assert_called_with(
-        device_id="6000702DC087",
+        device_serial="6000702DC087",
         channel_id="ch0002",
         datapoint="odp0003",
         value="13",
@@ -160,7 +160,7 @@ async def test_set_exported_today(virtual_energy_battery):
     """Negative values should return 0"""
     await virtual_energy_battery.set_exported_today(-3.4)
     virtual_energy_battery._api.set_datapoint.assert_called_with(
-        device_id="6000702DC087",
+        device_serial="6000702DC087",
         channel_id="ch0002",
         datapoint="odp0003",
         value="0",
@@ -174,7 +174,7 @@ async def test_set_imported_total(virtual_energy_battery):
     """Values greater 0 should always work"""
     await virtual_energy_battery.set_imported_total(25)
     virtual_energy_battery._api.set_datapoint.assert_called_with(
-        device_id="6000702DC087",
+        device_serial="6000702DC087",
         channel_id="ch0002",
         datapoint="odp0004",
         value="25",
@@ -184,7 +184,7 @@ async def test_set_imported_total(virtual_energy_battery):
     """Float values should return integer"""
     await virtual_energy_battery.set_imported_total(13.7)
     virtual_energy_battery._api.set_datapoint.assert_called_with(
-        device_id="6000702DC087",
+        device_serial="6000702DC087",
         channel_id="ch0002",
         datapoint="odp0004",
         value="13",
@@ -194,7 +194,7 @@ async def test_set_imported_total(virtual_energy_battery):
     """Negative values should return 0"""
     await virtual_energy_battery.set_imported_total(-3.4)
     virtual_energy_battery._api.set_datapoint.assert_called_with(
-        device_id="6000702DC087",
+        device_serial="6000702DC087",
         channel_id="ch0002",
         datapoint="odp0004",
         value="0",
@@ -208,7 +208,7 @@ async def test_set_exported_total(virtual_energy_battery):
     """Values greater 0 should always work"""
     await virtual_energy_battery.set_exported_total(25)
     virtual_energy_battery._api.set_datapoint.assert_called_with(
-        device_id="6000702DC087",
+        device_serial="6000702DC087",
         channel_id="ch0002",
         datapoint="odp0005",
         value="25",
@@ -218,7 +218,7 @@ async def test_set_exported_total(virtual_energy_battery):
     """Float values should return integer"""
     await virtual_energy_battery.set_exported_total(13.7)
     virtual_energy_battery._api.set_datapoint.assert_called_with(
-        device_id="6000702DC087",
+        device_serial="6000702DC087",
         channel_id="ch0002",
         datapoint="odp0005",
         value="13",
@@ -228,7 +228,7 @@ async def test_set_exported_total(virtual_energy_battery):
     """Negative values should return 0"""
     await virtual_energy_battery.set_exported_total(-3.4)
     virtual_energy_battery._api.set_datapoint.assert_called_with(
-        device_id="6000702DC087",
+        device_serial="6000702DC087",
         channel_id="ch0002",
         datapoint="odp0005",
         value="0",

--- a/tests/test_virtual_energy_inverter.py
+++ b/tests/test_virtual_energy_inverter.py
@@ -30,7 +30,7 @@ def virtual_energy_inverter(mock_api):
     parameters = {}
 
     return VirtualEnergyInverter(
-        device_id="6000702DC087",
+        device_serial="6000702DC087",
         device_name="Device Name",
         channel_id="ch0003",
         channel_name="Channel Name",
@@ -46,7 +46,7 @@ async def test_set_current_power(virtual_energy_inverter):
     """Test to set current_power of the sensor."""
     await virtual_energy_inverter.set_current_power(435.7)
     virtual_energy_inverter._api.set_datapoint.assert_called_with(
-        device_id="6000702DC087",
+        device_serial="6000702DC087",
         channel_id="ch0003",
         datapoint="odp0002",
         value="435.7",
@@ -60,7 +60,7 @@ async def test_set_imported_today(virtual_energy_inverter):
     """Values greater 0 should always work"""
     await virtual_energy_inverter.set_imported_today(25)
     virtual_energy_inverter._api.set_datapoint.assert_called_with(
-        device_id="6000702DC087",
+        device_serial="6000702DC087",
         channel_id="ch0003",
         datapoint="odp0003",
         value="25",
@@ -70,7 +70,7 @@ async def test_set_imported_today(virtual_energy_inverter):
     """Float values should return integer"""
     await virtual_energy_inverter.set_imported_today(13.7)
     virtual_energy_inverter._api.set_datapoint.assert_called_with(
-        device_id="6000702DC087",
+        device_serial="6000702DC087",
         channel_id="ch0003",
         datapoint="odp0003",
         value="13",
@@ -80,7 +80,7 @@ async def test_set_imported_today(virtual_energy_inverter):
     """Negative values should return 0"""
     await virtual_energy_inverter.set_imported_today(-3.4)
     virtual_energy_inverter._api.set_datapoint.assert_called_with(
-        device_id="6000702DC087",
+        device_serial="6000702DC087",
         channel_id="ch0003",
         datapoint="odp0003",
         value="0",
@@ -94,7 +94,7 @@ async def test_set_imported_total(virtual_energy_inverter):
     """Values greater 0 should always work"""
     await virtual_energy_inverter.set_imported_total(25)
     virtual_energy_inverter._api.set_datapoint.assert_called_with(
-        device_id="6000702DC087",
+        device_serial="6000702DC087",
         channel_id="ch0003",
         datapoint="odp0004",
         value="25",
@@ -104,7 +104,7 @@ async def test_set_imported_total(virtual_energy_inverter):
     """Float values should return integer"""
     await virtual_energy_inverter.set_imported_total(13.7)
     virtual_energy_inverter._api.set_datapoint.assert_called_with(
-        device_id="6000702DC087",
+        device_serial="6000702DC087",
         channel_id="ch0003",
         datapoint="odp0004",
         value="13",
@@ -114,7 +114,7 @@ async def test_set_imported_total(virtual_energy_inverter):
     """Negative values should return 0"""
     await virtual_energy_inverter.set_imported_total(-3.4)
     virtual_energy_inverter._api.set_datapoint.assert_called_with(
-        device_id="6000702DC087",
+        device_serial="6000702DC087",
         channel_id="ch0003",
         datapoint="odp0004",
         value="0",

--- a/tests/test_virtual_energy_two_way_meter.py
+++ b/tests/test_virtual_energy_two_way_meter.py
@@ -33,7 +33,7 @@ def virtual_energy_two_way_meter(mock_api):
     parameters = {}
 
     return VirtualEnergyTwoWayMeter(
-        device_id="6000702DC087",
+        device_serial="6000702DC087",
         device_name="Device Name",
         channel_id="ch0001",
         channel_name="Channel Name",
@@ -49,7 +49,7 @@ async def test_set_current_power(virtual_energy_two_way_meter):
     """Test to set battery_power of the sensor."""
     await virtual_energy_two_way_meter.set_current_power(435.7)
     virtual_energy_two_way_meter._api.set_datapoint.assert_called_with(
-        device_id="6000702DC087",
+        device_serial="6000702DC087",
         channel_id="ch0001",
         datapoint="odp0000",
         value="435.7",
@@ -63,7 +63,7 @@ async def test_set_imported_today(virtual_energy_two_way_meter):
     """Values greater 0 should always work"""
     await virtual_energy_two_way_meter.set_imported_today(25)
     virtual_energy_two_way_meter._api.set_datapoint.assert_called_with(
-        device_id="6000702DC087",
+        device_serial="6000702DC087",
         channel_id="ch0001",
         datapoint="odp0002",
         value="25",
@@ -73,7 +73,7 @@ async def test_set_imported_today(virtual_energy_two_way_meter):
     """Float values should return integer"""
     await virtual_energy_two_way_meter.set_imported_today(13.7)
     virtual_energy_two_way_meter._api.set_datapoint.assert_called_with(
-        device_id="6000702DC087",
+        device_serial="6000702DC087",
         channel_id="ch0001",
         datapoint="odp0002",
         value="13",
@@ -83,7 +83,7 @@ async def test_set_imported_today(virtual_energy_two_way_meter):
     """Negative values should return 0"""
     await virtual_energy_two_way_meter.set_imported_today(-3.4)
     virtual_energy_two_way_meter._api.set_datapoint.assert_called_with(
-        device_id="6000702DC087",
+        device_serial="6000702DC087",
         channel_id="ch0001",
         datapoint="odp0002",
         value="0",
@@ -97,7 +97,7 @@ async def test_set_exported_today(virtual_energy_two_way_meter):
     """Values greater 0 should always work"""
     await virtual_energy_two_way_meter.set_exported_today(25)
     virtual_energy_two_way_meter._api.set_datapoint.assert_called_with(
-        device_id="6000702DC087",
+        device_serial="6000702DC087",
         channel_id="ch0001",
         datapoint="odp0003",
         value="25",
@@ -107,7 +107,7 @@ async def test_set_exported_today(virtual_energy_two_way_meter):
     """Float values should return integer"""
     await virtual_energy_two_way_meter.set_exported_today(13.7)
     virtual_energy_two_way_meter._api.set_datapoint.assert_called_with(
-        device_id="6000702DC087",
+        device_serial="6000702DC087",
         channel_id="ch0001",
         datapoint="odp0003",
         value="13",
@@ -117,7 +117,7 @@ async def test_set_exported_today(virtual_energy_two_way_meter):
     """Negative values should return 0"""
     await virtual_energy_two_way_meter.set_exported_today(-3.4)
     virtual_energy_two_way_meter._api.set_datapoint.assert_called_with(
-        device_id="6000702DC087",
+        device_serial="6000702DC087",
         channel_id="ch0001",
         datapoint="odp0003",
         value="0",
@@ -131,7 +131,7 @@ async def test_set_imported_total(virtual_energy_two_way_meter):
     """Values greater 0 should always work"""
     await virtual_energy_two_way_meter.set_imported_total(25)
     virtual_energy_two_way_meter._api.set_datapoint.assert_called_with(
-        device_id="6000702DC087",
+        device_serial="6000702DC087",
         channel_id="ch0001",
         datapoint="odp0004",
         value="25",
@@ -141,7 +141,7 @@ async def test_set_imported_total(virtual_energy_two_way_meter):
     """Float values should return integer"""
     await virtual_energy_two_way_meter.set_imported_total(13.7)
     virtual_energy_two_way_meter._api.set_datapoint.assert_called_with(
-        device_id="6000702DC087",
+        device_serial="6000702DC087",
         channel_id="ch0001",
         datapoint="odp0004",
         value="13",
@@ -151,7 +151,7 @@ async def test_set_imported_total(virtual_energy_two_way_meter):
     """Negative values should return 0"""
     await virtual_energy_two_way_meter.set_imported_total(-3.4)
     virtual_energy_two_way_meter._api.set_datapoint.assert_called_with(
-        device_id="6000702DC087",
+        device_serial="6000702DC087",
         channel_id="ch0001",
         datapoint="odp0004",
         value="0",
@@ -165,7 +165,7 @@ async def test_set_exported_total(virtual_energy_two_way_meter):
     """Values greater 0 should always work"""
     await virtual_energy_two_way_meter.set_exported_total(25)
     virtual_energy_two_way_meter._api.set_datapoint.assert_called_with(
-        device_id="6000702DC087",
+        device_serial="6000702DC087",
         channel_id="ch0001",
         datapoint="odp0005",
         value="25",
@@ -175,7 +175,7 @@ async def test_set_exported_total(virtual_energy_two_way_meter):
     """Float values should return integer"""
     await virtual_energy_two_way_meter.set_exported_total(13.7)
     virtual_energy_two_way_meter._api.set_datapoint.assert_called_with(
-        device_id="6000702DC087",
+        device_serial="6000702DC087",
         channel_id="ch0001",
         datapoint="odp0005",
         value="13",
@@ -185,7 +185,7 @@ async def test_set_exported_total(virtual_energy_two_way_meter):
     """Negative values should return 0"""
     await virtual_energy_two_way_meter.set_exported_total(-3.4)
     virtual_energy_two_way_meter._api.set_datapoint.assert_called_with(
-        device_id="6000702DC087",
+        device_serial="6000702DC087",
         channel_id="ch0001",
         datapoint="odp0005",
         value="0",

--- a/tests/test_virtual_rain_sensor.py
+++ b/tests/test_virtual_rain_sensor.py
@@ -27,7 +27,7 @@ def virtual_rain_sensor(mock_api):
     parameters = {}
 
     return VirtualRainSensor(
-        device_id="6000A0EA2CF4",
+        device_serial="6000A0EA2CF4",
         device_name="Device Name",
         channel_id="ch0001",
         channel_name="Channel Name",
@@ -43,7 +43,7 @@ async def test_turn_on(virtual_rain_sensor):
     """Test to activate the sensor."""
     await virtual_rain_sensor.turn_on()
     virtual_rain_sensor._api.set_datapoint.assert_called_with(
-        device_id="6000A0EA2CF4",
+        device_serial="6000A0EA2CF4",
         channel_id="ch0001",
         datapoint="odp0000",
         value="1",
@@ -56,7 +56,7 @@ async def test_turn_off(virtual_rain_sensor):
     """Test to deactivate the sensor."""
     await virtual_rain_sensor.turn_off()
     virtual_rain_sensor._api.set_datapoint.assert_called_with(
-        device_id="6000A0EA2CF4",
+        device_serial="6000A0EA2CF4",
         channel_id="ch0001",
         datapoint="odp0000",
         value="0",

--- a/tests/test_virtual_switch_actuator.py
+++ b/tests/test_virtual_switch_actuator.py
@@ -33,7 +33,7 @@ def virtual_switch_actuator(mock_api):
     parameters = {}
 
     return VirtualSwitchActuator(
-        device_id="60004F56EA24",
+        device_serial="60004F56EA24",
         device_name="Device Name",
         channel_id="ch0000",
         channel_name="Channel Name",
@@ -56,7 +56,7 @@ async def test_turn_on(virtual_switch_actuator):
     await virtual_switch_actuator.turn_on()
     assert virtual_switch_actuator.state is True
     virtual_switch_actuator._api.set_datapoint.assert_called_with(
-        device_id="60004F56EA24",
+        device_serial="60004F56EA24",
         channel_id="ch0000",
         datapoint="odp0000",
         value="1",
@@ -69,7 +69,7 @@ async def test_turn_off(virtual_switch_actuator):
     await virtual_switch_actuator.turn_off()
     assert virtual_switch_actuator.state is False
     virtual_switch_actuator._api.set_datapoint.assert_called_with(
-        device_id="60004F56EA24",
+        device_serial="60004F56EA24",
         channel_id="ch0000",
         datapoint="odp0000",
         value="0",
@@ -83,7 +83,7 @@ async def test_refresh_state(virtual_switch_actuator):
     await virtual_switch_actuator.refresh_state()
     assert virtual_switch_actuator.state is True
     virtual_switch_actuator._api.get_datapoint.assert_called_with(
-        device_id="60004F56EA24",
+        device_serial="60004F56EA24",
         channel_id="ch0000",
         datapoint="odp0000",
     )

--- a/tests/test_virtual_temperature_sensor.py
+++ b/tests/test_virtual_temperature_sensor.py
@@ -28,7 +28,7 @@ def virtual_temperature_sensor(mock_api):
     parameters = {}
 
     return VirtualTemperatureSensor(
-        device_id="6000A0EA2CF4",
+        device_serial="6000A0EA2CF4",
         device_name="Device Name",
         channel_id="ch0002",
         channel_name="Channel Name",
@@ -44,7 +44,7 @@ async def test_turn_on(virtual_temperature_sensor):
     """Test to activate the sensor."""
     await virtual_temperature_sensor.turn_on()
     virtual_temperature_sensor._api.set_datapoint.assert_called_with(
-        device_id="6000A0EA2CF4",
+        device_serial="6000A0EA2CF4",
         channel_id="ch0002",
         datapoint="odp0000",
         value="1",
@@ -57,7 +57,7 @@ async def test_turn_off(virtual_temperature_sensor):
     """Test to deactivate the sensor."""
     await virtual_temperature_sensor.turn_off()
     virtual_temperature_sensor._api.set_datapoint.assert_called_with(
-        device_id="6000A0EA2CF4",
+        device_serial="6000A0EA2CF4",
         channel_id="ch0002",
         datapoint="odp0000",
         value="0",
@@ -70,7 +70,7 @@ async def test_set_temperature(virtual_temperature_sensor):
     """Test to set temperature of the sensor."""
     await virtual_temperature_sensor.set_temperature(-15.6)
     virtual_temperature_sensor._api.set_datapoint.assert_called_with(
-        device_id="6000A0EA2CF4",
+        device_serial="6000A0EA2CF4",
         channel_id="ch0002",
         datapoint="odp0001",
         value="-15.6",

--- a/tests/test_virtual_wind_sensor.py
+++ b/tests/test_virtual_wind_sensor.py
@@ -27,7 +27,7 @@ def virtual_wind_sensor(mock_api):
     parameters = {}
 
     return VirtualWindSensor(
-        device_id="6000A0EA2CF4",
+        device_serial="6000A0EA2CF4",
         device_name="Device Name",
         channel_id="ch0003",
         channel_name="Channel Name",
@@ -43,7 +43,7 @@ async def test_turn_on(virtual_wind_sensor):
     """Test to activate the sensor."""
     await virtual_wind_sensor.turn_on()
     virtual_wind_sensor._api.set_datapoint.assert_called_with(
-        device_id="6000A0EA2CF4",
+        device_serial="6000A0EA2CF4",
         channel_id="ch0003",
         datapoint="odp0000",
         value="1",
@@ -56,7 +56,7 @@ async def test_turn_off(virtual_wind_sensor):
     """Test to deactivate the sensor."""
     await virtual_wind_sensor.turn_off()
     virtual_wind_sensor._api.set_datapoint.assert_called_with(
-        device_id="6000A0EA2CF4",
+        device_serial="6000A0EA2CF4",
         channel_id="ch0003",
         datapoint="odp0000",
         value="0",
@@ -70,7 +70,7 @@ async def test_set_speed(virtual_wind_sensor):
     """Greater than 0 is ok"""
     await virtual_wind_sensor.set_speed(5)
     virtual_wind_sensor._api.set_datapoint.assert_called_with(
-        device_id="6000A0EA2CF4",
+        device_serial="6000A0EA2CF4",
         channel_id="ch0003",
         datapoint="odp0003",
         value="5",
@@ -80,7 +80,7 @@ async def test_set_speed(virtual_wind_sensor):
     """Below 0 is always 0"""
     await virtual_wind_sensor.set_speed(-7.5)
     virtual_wind_sensor._api.set_datapoint.assert_called_with(
-        device_id="6000A0EA2CF4",
+        device_serial="6000A0EA2CF4",
         channel_id="ch0003",
         datapoint="odp0003",
         value="0",
@@ -94,7 +94,7 @@ async def test_set_force(virtual_wind_sensor):
     """between 0 and 12 is ok"""
     await virtual_wind_sensor.set_force(5)
     virtual_wind_sensor._api.set_datapoint.assert_called_with(
-        device_id="6000A0EA2CF4",
+        device_serial="6000A0EA2CF4",
         channel_id="ch0003",
         datapoint="odp0001",
         value="5",
@@ -104,7 +104,7 @@ async def test_set_force(virtual_wind_sensor):
     """Float values should return integer"""
     await virtual_wind_sensor.set_force(5.5)
     virtual_wind_sensor._api.set_datapoint.assert_called_with(
-        device_id="6000A0EA2CF4",
+        device_serial="6000A0EA2CF4",
         channel_id="ch0003",
         datapoint="odp0001",
         value="5",
@@ -114,7 +114,7 @@ async def test_set_force(virtual_wind_sensor):
     """Below 0 is always 0"""
     await virtual_wind_sensor.set_force(-7.5)
     virtual_wind_sensor._api.set_datapoint.assert_called_with(
-        device_id="6000A0EA2CF4",
+        device_serial="6000A0EA2CF4",
         channel_id="ch0003",
         datapoint="odp0001",
         value="0",
@@ -124,7 +124,7 @@ async def test_set_force(virtual_wind_sensor):
     """Above 12 is always 12"""
     await virtual_wind_sensor.set_force(15)
     virtual_wind_sensor._api.set_datapoint.assert_called_with(
-        device_id="6000A0EA2CF4",
+        device_serial="6000A0EA2CF4",
         channel_id="ch0003",
         datapoint="odp0001",
         value="12",

--- a/tests/test_virtual_window_door_sensor.py
+++ b/tests/test_virtual_window_door_sensor.py
@@ -27,7 +27,7 @@ def virtual_window_door_sensor(mock_api):
     parameters = {}
 
     return VirtualWindowDoorSensor(
-        device_id="60002AE2F1BE",
+        device_serial="60002AE2F1BE",
         device_name="Device Name",
         channel_id="ch0000",
         channel_name="Channel Name",
@@ -43,7 +43,7 @@ async def test_turn_on(virtual_window_door_sensor):
     """Test to activate the sensor."""
     await virtual_window_door_sensor.turn_on()
     virtual_window_door_sensor._api.set_datapoint.assert_called_with(
-        device_id="60002AE2F1BE",
+        device_serial="60002AE2F1BE",
         channel_id="ch0000",
         datapoint="odp000c",
         value="1",
@@ -56,7 +56,7 @@ async def test_turn_off(virtual_window_door_sensor):
     """Test to deactivate the sensor."""
     await virtual_window_door_sensor.turn_off()
     virtual_window_door_sensor._api.set_datapoint.assert_called_with(
-        device_id="60002AE2F1BE",
+        device_serial="60002AE2F1BE",
         channel_id="ch0000",
         datapoint="odp000c",
         value="0",

--- a/tests/test_wind_sensor.py
+++ b/tests/test_wind_sensor.py
@@ -20,7 +20,7 @@ def get_wind_sensor(mock_api):
     parameters = {"par002e": "5", "par0047": "2", "par0048": "7"}
 
     return WindSensor(
-        device_id="7EB1000021C5",
+        device_serial="7EB1000021C5",
         device_name="Device Name",
         channel_id="ch0003",
         channel_name="Channel Name",
@@ -60,7 +60,7 @@ async def test_refresh_state(wind_sensor):
     assert wind_sensor.alarm is True
     assert wind_sensor.force == 1
     wind_sensor._api.get_datapoint.assert_called_with(
-        device_id="7EB1000021C5",
+        device_serial="7EB1000021C5",
         channel_id="ch0003",
         datapoint="odp0001",
     )

--- a/tests/test_window_door_sensor.py
+++ b/tests/test_window_door_sensor.py
@@ -26,7 +26,7 @@ def window_door_sensor(mock_api):
     parameters = {"par0010": "2"}
 
     return WindowDoorSensor(
-        device_id="ABB28CBC3651",
+        device_serial="ABB28CBC3651",
         device_name="Device Name",
         channel_id="ch0000",
         channel_name="Channel Name",
@@ -51,7 +51,7 @@ async def test_refresh_state(window_door_sensor):
     await window_door_sensor.refresh_state()
     assert window_door_sensor.state is True
     window_door_sensor._api.get_datapoint.assert_called_with(
-        device_id="ABB28CBC3651",
+        device_serial="ABB28CBC3651",
         channel_id="ch0000",
         datapoint="odp0000",
     )


### PR DESCRIPTION
There's a bit more going on in this PR than I had originally planned. But in contains some nice improvements. Sorry in advance for the size of this one.

- Most of the changes are changing `device_id` to `device_serial`. There is already a `device_id` in the device object so this became confusing as there's 2 device_id's with different values. The term `serial` is also used in the Free@Home Swagger documentation so I stuck with that. This created a bigger refactor than I had originally thought.
- Added a new `Device` class, this is a boiler late class right now, it just holds the attributes of the device. But in future changes it should be able to handle device level updates (parameters?) with the ability to run callbacks to Home Assistant on changes.
- In the FreeAtHome class I'm adding a method to `load_devices()` which will populate a new `self._devices` attribute. That `self._devices` will be used to populate `self._channels`.
  - I've added some helper functions like `get_device_for_channel` and `get_device_by_serial` which will easily allow for finding a device for a channel by either providing the `self._channels` key, or the device serial stored in the channel class.
  - Added a number of tests to cover the new code.
  - We we're also getting the error/warning `Unclosed client session` when running tests because not all client sessions were being closed in the tests. I've adjust the tests to ensure it's correctly closing the sessions when needed and we no longer get those errors.