### PR TITLE
Additional Refactor - Code Clean-Up

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ There is one class which is designed to only interact with the api. This should 
 There's is one endpoint that'll return the entire Free@Home configuration, including all devices. This example shows how to fetch and display that. Keep in mind the devices returned are are just Python `dict` objects.
 
 ```python
-from abbfreeathome.api import FreeAtHomeApi
+from abbfreeathome import FreeAtHomeApi
 import asyncio
 import logging
 
@@ -251,8 +251,7 @@ There an additional class called `FreeAtHome`. This class attempts to put it all
 This example will load the `FreeAtHome` class with all potential channels from the api. Once loaded another function `get_channels_by_class` is used to pull all channels that fall under a specific "class".
 
 ```python
-from abbfreeathome.api import FreeAtHomeApi
-from abbfreeathome.freeathome import FreeAtHome
+from abbfreeathome import FreeAtHome, FreeAtHomeApi
 from abbfreeathome.channels.switch_actuator import SwitchActuator
 import logging
 import asyncio
@@ -285,8 +284,7 @@ The Free@Home local api also exposes a websocket. With this library you can conn
 In addition, the library "channels" can register and run any callbacks when the state changes. Allowing outside code (e.g. Home Assistant) to get notified on changes.
 
 ```python
-from abbfreeathome.api import FreeAtHomeApi
-from abbfreeathome.freeathome import FreeAtHome
+from abbfreeathome import FreeAtHome, FreeAtHomeApi
 from abbfreeathome.channels.switch_actuator import SwitchActuator
 import logging
 import asyncio

--- a/src/abbfreeathome/device.py
+++ b/src/abbfreeathome/device.py
@@ -47,7 +47,7 @@ class Device:
         self._native_id = native_id
         self._parameters = parameters or {}
         self._channels_data = channels_data or {}
-        self._channels: dict[str, Base] | None = None
+        self._channels: dict[str, Base] = {}
 
         # Expose api as public attribute
         self.api: FreeAtHomeApi = api
@@ -139,7 +139,7 @@ class Device:
 
     def clear_channels(self):
         """Clear channels from the device."""
-        self._channels = None
+        self._channels.clear()
 
     async def load_channels(self):
         """Load the channels object."""
@@ -151,7 +151,7 @@ class Device:
         )
 
         # Create channels dictionary
-        self._channels = {}
+        self.clear_channels()
         for channel_id, channel_data in self._channels_data.items():
             # Determine channel class based on function ID
             _function_id = channel_data.get("functionID")

--- a/src/abbfreeathome/freeathome.py
+++ b/src/abbfreeathome/freeathome.py
@@ -75,8 +75,8 @@ class FreeAtHome:
                     continue
 
                 # Use the same key format as before: "device_serial/channel_id"
-                channel_key = f"{device_serial}/{channel_id}"
-                _all_channels[channel_key] = channel
+                channel_serial = f"{device_serial}/{channel_id}"
+                _all_channels[channel_serial] = channel
 
         return _all_channels
 
@@ -170,18 +170,22 @@ class FreeAtHome:
             return
 
         _device_serial, _channel_id = channel_serial.split("/", 1)
-        _device = self._devices.get(_device_serial)
-        if _device and _device.channels:
-            # Remove the specific channel from the device
-            _device.channels.pop(_channel_id, None)
-            # Invalidate the filtered channels cache
-            self._filtered_channels = None
+        try:
+            _device = self._devices[_device_serial]
+            if _device.channels is not None:
+                _device.channels.pop(_channel_id)
+                # Invalidate the filtered channels cache
+                self._filtered_channels = None
+        except KeyError:
+            pass
 
     def unload_device_by_serial(self, device_serial: str):
         """Unload a device by its serial ID."""
-        if device_serial in self._devices:
+        try:
             self._devices.pop(device_serial)
             self._filtered_channels = None
+        except KeyError:
+            pass
 
     async def ws_close(self):
         """Close the websocker connection."""

--- a/src/abbfreeathome/freeathome.py
+++ b/src/abbfreeathome/freeathome.py
@@ -38,12 +38,81 @@ class FreeAtHome:
         self._devices.clear()
         self._filtered_channels = None
 
+    def get_channels(self) -> dict[str, Base]:
+        """Get channels from all devices based on class filters."""
+        if self._filtered_channels is None:
+            self._filtered_channels = self._build_filtered_channels()
+        return self._filtered_channels
+
+    def get_channels_by_class(self, channel_class: Base) -> list[Base]:
+        """Get the list of channels by class."""
+        _channels = self.get_channels()
+        return [
+            _channel
+            for _channel in _channels.values()
+            if type(_channel) is channel_class
+        ]
+
     async def get_config(self, refresh: bool = False) -> dict:
         """Get the Free@Home Configuration."""
         if self._config is None or refresh:
             self._config = await self.api.get_configuration()
 
         return self._config
+
+    def get_device_by_serial(self, device_serial: str) -> Device | None:
+        """Get a device by its serial ID."""
+        return self._devices.get(device_serial)
+
+    def get_devices(self) -> dict[str, Device]:
+        """Get the list of devices."""
+        return self._devices
+
+    async def load(self):
+        """Load from the Free@Home api into the FreeAtHome class."""
+        await self._load_devices()
+
+    def unload_channel(self, device_serial: str, channel_id: str):
+        """Unload a specific channel by device serial and channel id."""
+        try:
+            _device = self._devices[device_serial]
+            _device.channels.pop(channel_id)
+
+            # Invalidate the filtered channels cache
+            self._filtered_channels = None
+        except KeyError:
+            pass
+
+    def unload_device(self, device_serial: str):
+        """Unload a device by its serial ID."""
+        try:
+            self._devices.pop(device_serial)
+
+            # Invalidate the filtered channels cache
+            self._filtered_channels = None
+        except KeyError:
+            pass
+
+    async def update(self, data: dict):
+        """Update channel based on websocket data."""
+        _channels = self.get_channels()
+
+        for _datapoint_key, _datapoint_value in data.get("datapoints").items():
+            _unique_id = "/".join(_datapoint_key.split("/")[:-1])
+
+            try:
+                _channel = _channels[_unique_id]
+                _channel.update_channel(_datapoint_key, _datapoint_value)
+            except KeyError:
+                continue
+
+    async def ws_close(self):
+        """Close the websocker connection."""
+        await self.api.ws_close()
+
+    async def ws_listen(self):
+        """Listen on the websocket for updates to Free@Home objects."""
+        await self.api.ws_listen(callback=self.update)
 
     def _build_filtered_channels(self) -> dict[str, Base]:
         """Build a filtered dictionary of channels based on current filters."""
@@ -79,33 +148,6 @@ class FreeAtHome:
                 _all_channels[channel_serial] = channel
 
         return _all_channels
-
-    def get_channels(self) -> dict[str, Base]:
-        """Get channels from all devices based on class filters."""
-        if self._filtered_channels is None:
-            self._filtered_channels = self._build_filtered_channels()
-        return self._filtered_channels
-
-    def get_devices(self) -> dict[str, Device]:
-        """Get the list of devices."""
-        return self._devices
-
-    def get_device_by_serial(self, device_serial: str) -> Device | None:
-        """Get a device by its serial ID."""
-        return self._devices.get(device_serial)
-
-    def get_channels_by_class(self, channel_class: Base) -> list[Base]:
-        """Get the list of channels by class."""
-        _channels = self.get_channels()
-        return [
-            _channel
-            for _channel in _channels.values()
-            if type(_channel) is channel_class
-        ]
-
-    async def load(self):
-        """Load from the Free@Home api into the FreeAtHome class."""
-        await self._load_devices()
 
     async def _load_devices(self):
         """Load all devices into the devices object."""
@@ -159,51 +201,3 @@ class FreeAtHome:
 
         # Invalidate the filtered channels cache after loading devices
         self._filtered_channels = None
-
-    def unload_channel_by_channel_serial(self, channel_serial: str):
-        """
-        Unload a specific channel by its channel serial.
-
-        Channel serial format: device_serial/channel_id
-        """
-        if "/" not in channel_serial:
-            return
-
-        _device_serial, _channel_id = channel_serial.split("/", 1)
-        try:
-            _device = self._devices[_device_serial]
-            if _device.channels is not None:
-                _device.channels.pop(_channel_id)
-                # Invalidate the filtered channels cache
-                self._filtered_channels = None
-        except KeyError:
-            pass
-
-    def unload_device_by_serial(self, device_serial: str):
-        """Unload a device by its serial ID."""
-        try:
-            self._devices.pop(device_serial)
-            self._filtered_channels = None
-        except KeyError:
-            pass
-
-    async def ws_close(self):
-        """Close the websocker connection."""
-        await self.api.ws_close()
-
-    async def ws_listen(self):
-        """Listen on the websocket for updates to Free@Home objects."""
-        await self.api.ws_listen(callback=self.update)
-
-    async def update(self, data: dict):
-        """Update channel based on websocket data."""
-        _channels = self.get_channels()
-
-        for _datapoint_key, _datapoint_value in data.get("datapoints").items():
-            _unique_id = "/".join(_datapoint_key.split("/")[:-1])
-
-            try:
-                _channel = _channels[_unique_id]
-                _channel.update_channel(_datapoint_key, _datapoint_value)
-            except KeyError:
-                continue

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -50,7 +50,7 @@ def test_device_initialization_minimal(mock_api, mock_device):
     assert device.native_id is None
     assert device.parameters == {}
     assert device.channels_data == {}
-    assert device.channels is None  # Channels None until load_channels() called
+    assert device.channels == {}
     assert device.is_virtual is False
 
 
@@ -586,7 +586,7 @@ def test_device_clear_channels(mock_api, mock_device):
     # Set some channels and then clear them
     device._channels = {"ch0000": "some_channel"}
     device.clear_channels()
-    assert device._channels is None
+    assert device._channels == {}
 
 
 @pytest.mark.asyncio

--- a/tests/test_device_channel_composition.py
+++ b/tests/test_device_channel_composition.py
@@ -76,7 +76,7 @@ def test_device_with_channels(mock_api, mock_device):
 def test_device_channels_property_returns_channel_objects(test_device_with_channels):
     """Test that device.channels returns Channel objects."""
     # Since channels property now returns None until load_channels is called
-    assert test_device_with_channels.channels is None
+    assert test_device_with_channels.channels == {}
 
 
 @pytest.mark.asyncio

--- a/tests/test_freeathome.py
+++ b/tests/test_freeathome.py
@@ -911,3 +911,13 @@ async def test_unload_channel_invalid_serial(api_mock):
     # Should not change anything
     updated_channels = freeathome.get_channels()
     assert len(updated_channels) == initial_count
+
+    # Test with device that has channels set to None
+    device = freeathome.get_device_by_serial("ABB7F500E17A")
+    if device:
+        device.clear_channels()  # This sets device._channels = None
+        freeathome.unload_channel_by_channel_serial("ABB7F500E17A/ch0000")
+
+        # Should not change anything since channels is None
+        updated_channels = freeathome.get_channels()
+        assert len(updated_channels) == initial_count


### PR DESCRIPTION
This provides some additional code clean-up after the large refactor.

- Ensure `self._channels` in the `Device` class is always a dictionary instead of assigning it to `None`. This makes some other logic simplier (no need to check for None type). And makes it easy to clear the attribute with `clear()` dict function.
- Ordered the functions in FreeAtHome alphabetically to make them easier to find (private functions at the bottom).
- Update function `unload_channel_by_channel_serial` to just `unload_channel`. Take in the device serial and channel id as separate arguments to simplify the logic in the function.
- Update function `unload_device_by_device_serial` to just `unload_device`.
- Update tests to match.