### PR TITLE
Add FID_DES_LEVEL_CALL_SENSOR for DesDoorRingingSensor

### DIFF
--- a/src/abbfreeathome/const.py
+++ b/src/abbfreeathome/const.py
@@ -61,6 +61,7 @@ FUNCTION_DEVICE_MAPPING: dict[Function, Base] = {
     Function.FID_COLORTEMPERATURE_ACTUATOR: ColorTemperatureActuator,
     Function.FID_DES_DOOR_OPENER_ACTUATOR: DesDoorOpenerActuator,
     Function.FID_DES_DOOR_RINGING_SENSOR: DesDoorRingingSensor,
+    Function.FID_DES_LEVEL_CALL_SENSOR: DesDoorRingingSensor,
     Function.FID_DIMMING_ACTUATOR: DimmingActuator,
     Function.FID_DIMMING_ACTUATOR_TYPE0: DimmingActuator,
     Function.FID_DIMMING_ACTUATOR_TYPE1: DimmingActuator,


### PR DESCRIPTION
This is used for hallway-side apartment door ringing (level calls) on OneTouch 7 devices.

---
The OneTouch 7 panel acts as a SysAP,  and a Welcome IP or Welcome 2-wire indoor station and IP-Gateway.
It has a couple of other things that may be of interest (e.g. mute door bell), so here's the diagnostics report from HA for reference: 
[config_entry-abbfreeathome_ci-01JZM93VR733HYR8VW4P6DM5FH.json](https://github.com/user-attachments/files/21117322/config_entry-abbfreeathome_ci-01JZM93VR733HYR8VW4P6DM5FH.json)
 