### PR TITLE
Add FID_WELCOME_IP_BELL_INDICATOR_SENSOR for DesDoorRingingSensor

### DIFF
--- a/src/abbfreeathome/const.py
+++ b/src/abbfreeathome/const.py
@@ -118,6 +118,7 @@ FUNCTION_DEVICE_MAPPING: dict[Function, Base] = {
     Function.FID_SWITCH_SENSOR_ROCKER_TYPE2: SwitchSensor,
     Function.FID_TEMPERATURE_SENSOR: TemperatureSensor,
     Function.FID_TRIGGER: Trigger,
+    Function.FID_WELCOME_IP_BELL_INDICATOR_SENSOR: DesDoorRingingSensor,
     Function.FID_WIND_SENSOR: WindSensor,
     Function.FID_WINDOW_DOOR_POSITION_SENSOR: WindowDoorSensor,
     Function.FID_WINDOW_DOOR_SENSOR: WindowDoorSensor,


### PR DESCRIPTION
#200 isn't the event actually triggered by apt door ringing in my Welcome 2-wire installation. I'm hoping this one is.

That doesn't mean #200 was wrong per se, nonetheless apologies for opening multiple tiny PRs here...