### PR TITLE
Adds new function `get_channels_by_device` to FreeAtHome

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -167,7 +167,7 @@ pythonpath = [
 FREEATHOME_MAX_REQUEST_TRIES = "1"
 
 [tool.coverage.run]
-omit = ["*/tests/*"]
+omit = ["*/tests/*", "test_*"]
 
 [tool.coverage.report]
 exclude_lines = [

--- a/src/abbfreeathome/freeathome.py
+++ b/src/abbfreeathome/freeathome.py
@@ -45,6 +45,15 @@ class FreeAtHome:
             self._filtered_channels = self._build_filtered_channels()
         return self._filtered_channels
 
+    def get_channels_by_device(self, device_serial: str) -> list[Base]:
+        """Get the list of channels by device."""
+        _channels = self.get_channels()
+        return [
+            _channel
+            for key, _channel in _channels.items()
+            if key.startswith(f"{device_serial}/")
+        ]
+
     def get_channels_by_class(self, channel_class: Base) -> list[Base]:
         """Get the list of channels by class."""
         _channels = self.get_channels()

--- a/tests/test_freeathome.py
+++ b/tests/test_freeathome.py
@@ -425,6 +425,41 @@ async def test_get_channels_by_class(freeathome):
 
 
 @pytest.mark.asyncio
+async def test_get_channels_by_device(freeathome):
+    """Test the get_channels_by_device function."""
+    await freeathome.load()
+
+    # Test getting channels for a specific device that has multiple channels
+    channels_device1 = freeathome.get_channels_by_device("ABB7F500E17A")
+    assert len(channels_device1) == 2  # Device has ch0000 and ch0003
+
+    # Verify the channels belong to the correct device
+    for channel in channels_device1:
+        assert channel.device_serial == "ABB7F500E17A"
+
+    # Test getting channels for another device
+    channels_device2 = freeathome.get_channels_by_device("ABB7F62F6C0B")
+    assert len(channels_device2) == 2  # Device has ch0000 and ch0003
+
+    # Verify the channels belong to the correct device
+    for channel in channels_device2:
+        assert channel.device_serial == "ABB7F62F6C0B"
+
+    # Test getting channels for a device with no channels (should return empty list)
+    channels_empty = freeathome.get_channels_by_device("NONEXISTENT")
+    assert len(channels_empty) == 0
+    assert isinstance(channels_empty, list)
+
+    # Test getting channels for a device that exists but may have filtered channels
+    # BEED509C0001 has one channel but it might be filtered out due to room/floor
+    # mismatch
+    channels_filtered = freeathome.get_channels_by_device("BEED509C0001")
+    # This should return 0 because the channel has floor "02"/room "06"
+    # but device is floor "01"/room "01"
+    assert len(channels_filtered) == 0
+
+
+@pytest.mark.asyncio
 async def test_load(freeathome):
     """Test the load function."""
     await freeathome.load()


### PR DESCRIPTION
This adds a new function `get_channels_by_device` to FreeAtHome which can be used by the Home Assistant integration (or any integration) to get the filtered channels by device serial.