### PR TITLE
Add SSL Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,32 @@ You can run a few tests to ensure everything is working as it should.
 1. In Visual Studio Code, Navigate to the `Testing` tab on the left and click `Run Tests` (Double Play Icon). This should run all Python Unit Tests. You can also run `Run Tests With Coverage` to get the code coverage results.
 2. In a new terminal window you can run `python3 -m build` to build and package up the python code.
 
+## SSL/TLS Support
+
+This library supports secure connections to your SysAP using SSL/TLS for both HTTPS and WebSockets (`wss`). When initializing the `FreeAtHomeApi`, you can control SSL verification using two optional parameters:
+
+- `verify_ssl` (bool): Defaults to `True`. The SysAP uses a self-signed certificate, if you do not want to provide a custom certificate file, you can set this to `False`. **Disabling verification is not recommended as it makes the connection insecure.**
+- `ssl_cert_ca_file` (str): The absolute path to a custom CA certificate file (`.pem` or `.crt`). This is used to verify the SysAP's certificate. You can fetch this certificate from the SysAP Local API connection settings under `Connection`.
+
+### Using the SysAP Self-Signed Certificate
+
+To connect securely to a SysAP using its self-signed certificate, you first need to download the certificate from the SysAP Local Api Settings.
+
+1.  Navigate to your SysAP's web interface (`http://<IP or HOSTNAME>`).
+2.  If you're connecting via https, your browser will warn you about an insecure connection. Proceed anyway.
+3.  Navigate to `Configuration` --> `Settings` --> `free@home - Settings` --> `Local API`.
+4.  Under the `Connection`, you'll have the option to `Generate Certificate`, or `Download certificate`. Download the certificate to your machine (e.g., `sysap.crt`) and provide its path to the `ssl_cert_ca_file` parameter.
+
+```python
+# Example of connecting with a custom certificate
+api = FreeAtHomeApi(
+    host="https://<IP or HOSTNAME>",
+    username="installer",
+    password="<password>",
+    ssl_cert_ca_file="/path/to/your/sysap.crt"
+)
+```
+
 ## Examples
 
 Below are a number of examples on how to use the library. These examples use the above directory and virtual environment.
@@ -232,7 +258,11 @@ if __name__ == "__main__":
 
     # Create an instance of the free@home api
     _fah_api = FreeAtHomeApi(
-        host="http://<IP or HOSTNAME>", username="installer", password="<password>"
+        host="https://<IP or HOSTNAME>",
+        username="installer",
+        password="<password>",
+        verify_ssl=True,
+        ssl_cert_ca_file="/path/to/your/sysap.crt",
     )
 
     # Pull SysAP Configuration
@@ -262,7 +292,11 @@ if __name__ == "__main__":
     # Create an instance of the FreeAtHome class.
     _free_at_home = FreeAtHome(
         api=FreeAtHomeApi(
-          host="http://<IP or HOSTNAME>", username="installer", password="<password>"
+            host="https://<IP or HOSTNAME>",
+            username="installer",
+            password="<password>",
+            verify_ssl=True,
+            ssl_cert_ca_file="/path/to/your/sysap.crt",
         )
     )
 
@@ -293,7 +327,11 @@ import asyncio
 async def websocket_test():
     # Create an instance of the api using context management
     async with FreeAtHomeApi(
-        host="http://<IP or HOSTNAME>", username="installer", password="<password>"
+        host="https://<IP or HOSTNAME>",
+        username="installer",
+        password="<password>",
+        verify_ssl=True,
+        ssl_cert_ca_file="/path/to/your/sysap.crt",
     ) as _free_at_home_api:
         # Create an Instance of the FreeAtHome class
         _free_at_home = FreeAtHome(_free_at_home_api)
@@ -348,7 +386,11 @@ async def main():
     # Create an instance of the FreeAtHome class.
     _free_at_home = FreeAtHome(
         api=FreeAtHomeApi(
-          host="http://<IP or HOSTNAME>", username="installer", password="<password>"
+            host="https://<IP or HOSTNAME>",
+            username="installer",
+            password="<password>",
+            verify_ssl=True,
+            ssl_cert_ca_file="/path/to/your/sysap.crt",
         )
     )
 
@@ -386,14 +428,3 @@ async def main():
 if __name__ == "__main__":
     asyncio.run(main())
 ```
-
-## TODO
-
-There are a number of items that still need to be done.
-
-- ~~Implement format and linting checking in a GitHub actions pipeline using Ruff.~~
-  - ~~https://docs.astral.sh/ruff/integrations/~~
-- ~~Add GitHub actions for cutting a release and pushing to PyPi automatically.~~
-- ~~Implement unit testing.~~
-- Implement SSL on both HTTPS and WSS requests.
-  - The Free@Home system will provide a certificate which can be used to validate the connection, can this be used in Home Assistant?

--- a/src/abbfreeathome/__init__.py
+++ b/src/abbfreeathome/__init__.py
@@ -1,6 +1,6 @@
 """ABB-Free@Home API library."""
 
-from .api import FreeAtHomeApi
+from .api import FreeAtHomeApi, FreeAtHomeSettings
 from .freeathome import FreeAtHome
 
-__all__ = ["FreeAtHomeApi", "FreeAtHome"]
+__all__ = ["FreeAtHomeApi", "FreeAtHome", "FreeAtHomeSettings"]

--- a/src/abbfreeathome/api.py
+++ b/src/abbfreeathome/api.py
@@ -68,8 +68,8 @@ class SSLContextMixin:
         """Get the SSL context for requests."""
         if not self._verify_ssl:
             return False
-        if self._ssl_cert_path:
-            return ssl.create_default_context(cafile=self._ssl_cert_path)
+        if self._ssl_cert_ca_file:
+            return ssl.create_default_context(cafile=self._ssl_cert_ca_file)
         return True
 
 
@@ -85,13 +85,13 @@ class FreeAtHomeSettings(SSLContextMixin):
         host: str,
         client_session: ClientSession = None,
         verify_ssl: bool = True,
-        ssl_cert_path: str | None = None,
+        ssl_cert_ca_file: str | None = None,
     ) -> None:
         """Initialize the FreeAtHomeSettings class."""
         self._host: str = host
         self._client_session: ClientSession = client_session
         self._verify_ssl: bool = verify_ssl
-        self._ssl_cert_path: str | None = ssl_cert_path
+        self._ssl_cert_ca_file: str | None = ssl_cert_ca_file
 
     async def __aenter__(self):
         """Async enter and return self."""
@@ -193,7 +193,7 @@ class FreeAtHomeApi(SSLContextMixin):
         client_session: ClientSession = None,
         ws_heartbeat: int = 30,
         verify_ssl: bool = True,
-        ssl_cert_path: str | None = None,
+        ssl_cert_ca_file: str | None = None,
     ) -> None:
         """Initialize the FreeAtHomeApi class."""
         self._host = host.rstrip("/")
@@ -202,7 +202,7 @@ class FreeAtHomeApi(SSLContextMixin):
         self._client_session = client_session
         self._ws_heartbeat = ws_heartbeat
         self._verify_ssl: bool = verify_ssl
-        self._ssl_cert_path: None | str = ssl_cert_path
+        self._ssl_cert_ca_file: None | str = ssl_cert_ca_file
 
     async def __aenter__(self):
         """Async enter and return self."""

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -811,3 +811,47 @@ async def test_ws_receive_unknown_message_type(api):
     # Function should complete without error even for unknown message types
     result = await api.ws_receive()
     assert result is None
+
+
+def test_settings_get_ssl_context_no_verify():
+    """Test _get_ssl_context returns False when verify_ssl is False."""
+    settings = FreeAtHomeSettings(host="http://192.168.1.1", verify_ssl=False)
+    assert settings._get_ssl_context() is False
+
+
+def test_settings_get_ssl_context_with_cert_path():
+    """Test _get_ssl_context returns SSLContext when ssl_cert_path is provided."""
+    settings = FreeAtHomeSettings(
+        host="http://192.168.1.1", verify_ssl=True, ssl_cert_path="dummy_path"
+    )
+    with patch("ssl.create_default_context") as mock_create_context:
+        mock_context = Mock()
+        mock_create_context.return_value = mock_context
+        context = settings._get_ssl_context()
+        assert context is mock_context
+        mock_create_context.assert_called_once_with(cafile="dummy_path")
+
+
+def test_api_get_ssl_context_no_verify():
+    """Test _get_ssl_context returns False when verify_ssl is False."""
+    api = FreeAtHomeApi(
+        host="http://192.168.1.1", username="user", password="pass", verify_ssl=False
+    )
+    assert api._get_ssl_context() is False
+
+
+def test_api_get_ssl_context_with_cert_path():
+    """Test _get_ssl_context returns SSLContext when ssl_cert_path is provided."""
+    api = FreeAtHomeApi(
+        host="http://192.168.1.1",
+        username="user",
+        password="pass",
+        verify_ssl=True,
+        ssl_cert_path="dummy_path",
+    )
+    with patch("ssl.create_default_context") as mock_create_context:
+        mock_context = Mock()
+        mock_create_context.return_value = mock_context
+        context = api._get_ssl_context()
+        assert context is mock_context
+        mock_create_context.assert_called_once_with(cafile="dummy_path")

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -820,9 +820,9 @@ def test_settings_get_ssl_context_no_verify():
 
 
 def test_settings_get_ssl_context_with_cert_path():
-    """Test _get_ssl_context returns SSLContext when ssl_cert_path is provided."""
+    """Test _get_ssl_context returns SSLContext when ssl_cert_ca_file is provided."""
     settings = FreeAtHomeSettings(
-        host="http://192.168.1.1", verify_ssl=True, ssl_cert_path="dummy_path"
+        host="http://192.168.1.1", verify_ssl=True, ssl_cert_ca_file="dummy_path"
     )
     with patch("ssl.create_default_context") as mock_create_context:
         mock_context = Mock()
@@ -841,13 +841,13 @@ def test_api_get_ssl_context_no_verify():
 
 
 def test_api_get_ssl_context_with_cert_path():
-    """Test _get_ssl_context returns SSLContext when ssl_cert_path is provided."""
+    """Test _get_ssl_context returns SSLContext when ssl_cert_ca_file is provided."""
     api = FreeAtHomeApi(
         host="http://192.168.1.1",
         username="user",
         password="pass",
         verify_ssl=True,
-        ssl_cert_path="dummy_path",
+        ssl_cert_ca_file="dummy_path",
     )
     with patch("ssl.create_default_context") as mock_create_context:
         mock_context = Mock()


### PR DESCRIPTION
This PR adds SSL support to the library. The `aiohttp` requests would support `https` connections if supported, but they would fail as the Free@Home SysAP uses a self-signed certificate.

This adds the ability to:

- Disabled SSL verifications on SSL connection, not recommended but an easy way to get SSL connections (which is better than no SSL connections).
- Add ability to provide the certificate provided by the SysAP for SSL verification to create a full trusted connected.

I've also added a check on the Websocket connection, if using `https` for the host, then use `wss` (instead of `ws`) for the websocket for a secure web socket connection.

@derjoerg, to test you might just want to attempt to connect to your SysAP via SSL.