### PR TITLE
This adds an additional exception/error handling for failed SSL connections

### DIFF
--- a/src/abbfreeathome/api.py
+++ b/src/abbfreeathome/api.py
@@ -14,6 +14,7 @@ from aiohttp.client import ClientSession, ClientWebSocketResponse
 from aiohttp.client_exceptions import (
     ClientConnectionError as AioHttpClientConnectionError,
     ClientResponseError as AioHttpClientResponseError,
+    ClientSSLError as AioClientSSLError,
     InvalidUrlClientError as AioHttpInvalidUrlClientError,
     WSServerHandshakeError as AioHttpWSServerHandshakeError,
 )
@@ -32,6 +33,7 @@ from .exceptions import (
     InvalidCredentialsException,
     InvalidHostException,
     SetDatapointFailureException,
+    SslErrorException,
     UserNotFoundException,
 )
 
@@ -118,6 +120,8 @@ class FreeAtHomeSettings(SSLContextMixin):
                 _response_json = await resp.json()
         except AioHttpInvalidUrlClientError as e:
             raise InvalidHostException(self._host) from e
+        except AioClientSSLError as e:
+            raise SslErrorException(self._host) from e
         except AioHttpClientConnectionError as e:
             raise ClientConnectionError(self._host) from e
 
@@ -330,6 +334,8 @@ class FreeAtHomeApi(SSLContextMixin):
                     _response_data = await resp.text()
         except AioHttpInvalidUrlClientError as e:
             raise InvalidHostException(self._host) from e
+        except AioClientSSLError as e:
+            raise SslErrorException(self._host) from e
         except AioHttpClientConnectionError as e:
             raise ClientConnectionError(self._host) from e
         except AioHttpClientResponseError as e:
@@ -398,6 +404,8 @@ class FreeAtHomeApi(SSLContextMixin):
                 _LOGGER.exception("Websocket Handshake Connection Error.")
                 await asyncio.sleep(retry_interval)
                 return
+            except AioClientSSLError as e:
+                raise SslErrorException(self._host) from e
             except AioHttpClientConnectionError:
                 _LOGGER.exception("Websocket Client Connection Error.")
                 await asyncio.sleep(retry_interval)

--- a/src/abbfreeathome/exceptions.py
+++ b/src/abbfreeathome/exceptions.py
@@ -14,6 +14,15 @@ class ClientConnectionError(FreeAtHomeException):
         super().__init__(self.message)
 
 
+class SslErrorException(FreeAtHomeException):
+    """Raise an exception for SSL certificate verification errors."""
+
+    def __init__(self, url: str) -> None:
+        """Initialize the SslErrorException class."""
+        self.message = f"SSL certificate verification failed for host {url}"
+        super().__init__(self.message)
+
+
 class ConnectionTimeoutException(FreeAtHomeException):
     """Raise an exception if the connection times out."""
 

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -4,6 +4,7 @@ import pytest
 
 from src.abbfreeathome.exceptions import (
     BadRequestException,
+    ClientConnectionError,
     ConnectionTimeoutException,
     ForbiddenAuthException,
     InvalidApiResponseException,
@@ -12,6 +13,7 @@ from src.abbfreeathome.exceptions import (
     InvalidDeviceChannelParameter,
     InvalidHostException,
     SetDatapointFailureException,
+    SslErrorException,
     UnknownCallbackAttributeException,
     UserNotFoundException,
 )
@@ -22,6 +24,13 @@ def test_connection_timeout_exception():
     with pytest.raises(ConnectionTimeoutException) as excinfo:
         raise ConnectionTimeoutException("192.168.1.1")
     assert str(excinfo.value) == "Connection timeout to host: 192.168.1.1"
+
+
+def test_client_connection_error():
+    """Test client connection error exception."""
+    with pytest.raises(ClientConnectionError) as excinfo:
+        raise ClientConnectionError("https://192.168.1.1")
+    assert str(excinfo.value) == "Cannot connect to host https://192.168.1.1"
 
 
 def test_forbidden_auth_exception():
@@ -118,4 +127,14 @@ def test_invalid_device_channel_parameter():
     assert str(excinfo.value) == (
         "Could not find parameter id for "
         "device: device1; channel: channel1; parameter id: 123"
+    )
+
+
+def test_ssl_error_exception():
+    """Test SSL error exception."""
+    with pytest.raises(SslErrorException) as excinfo:
+        raise SslErrorException("https://192.168.1.1")
+    assert (
+        str(excinfo.value)
+        == "SSL certificate verification failed for host https://192.168.1.1"
     )


### PR DESCRIPTION
I was taking a look at the Home Assistant integration on how to add in support for SSL and realized I didn't have any easy way to catch any SSL exceptions to either bubble up to the user via a specific `SSL connection failed` error message, or for possible zeroconf implementation of SSL with fallback to HTTP.

This PR adds a new exception `SslErrorException` that can be used for those scenarios.