### PR TITLE
Added support for locking of movement detectors

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ The current channels implemented within the library.
 | Name | Primary Functions | Properties |
 | ------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
 | BlindSensor | | `state`, `step_state`, `move_state` |
+| BlockableMovementDetector | `turn_on_blocked()`, `turn_off_blocked()` | `state`, `brightness`, `blocked` |
 | BrightnessSensor | | `state`, `alarm` |
 | CarbonMonoxideSensor | | `state` |
 | ColorTemperatureActuator | `turn_on()`, `turn_off()`, `set_brightness()`, `set_forced_position()`, `set_color_temperature()` | `state`, `brightness`, `forced_position`, `color_temperature`, `color_temperature_coolest`, `color_temperature_warmest` |
@@ -37,7 +38,7 @@ The current channels implemented within the library.
 | DimmingSensor\* | `turn_on_led()`, `turn_off_led()` | `state` |
 | ForceOnOffSensor | | `state` |
 | HeatingActuator | `set_position()` | `position` |
-| MovementDetector | `lock()`, `unlock()` | `state`, `brightness`, `locked` |
+| MovementDetector | | `state`, `brightness` |
 | RainSensor | | `state` |
 | RoomTemperatureController | `turn_on()`, `turn_off()`, `eco_on()`, `eco_off()`, `set_temperature()` | `state`, `current_temperature`, `valve`, `target_temperature`, `state_indication`, `eco_mode` |
 | SmokeDetector | | `state` |

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ The current channels implemented within the library.
 | DimmingSensor\* | `turn_on_led()`, `turn_off_led()` | `state` |
 | ForceOnOffSensor | | `state` |
 | HeatingActuator | `set_position()` | `position` |
-| MovementDetector | | `state`, `brightness` |
+| MovementDetector | `lock()`, `unlock()` | `state`, `brightness`, `locked` |
 | RainSensor | | `state` |
 | RoomTemperatureController | `turn_on()`, `turn_off()`, `eco_on()`, `eco_off()`, `set_temperature()` | `state`, `current_temperature`, `valve`, `target_temperature`, `state_indication`, `eco_mode` |
 | SmokeDetector | | `state` |

--- a/src/abbfreeathome/channels/movement_detector.py
+++ b/src/abbfreeathome/channels/movement_detector.py
@@ -1,4 +1,4 @@
-"""Free@Home MovementDetectorSensor Class."""
+"""Free@Home MovementDetector and BlockableMovementDetector Class."""
 
 from typing import TYPE_CHECKING, Any
 
@@ -15,12 +15,10 @@ class MovementDetector(Base):
     _state_refresh_pairings: list[Pairing] = [
         Pairing.AL_TIMED_MOVEMENT,
         Pairing.AL_BRIGHTNESS_LEVEL,
-        Pairing.AL_INFO_LOCKED_SENSOR,
     ]
     _callback_attributes: list[str] = [
         "state",
         "brightness",
-        "locked",
     ]
 
     def __init__(
@@ -37,7 +35,6 @@ class MovementDetector(Base):
         """Initialize the Free@Home MovementDetector class."""
         self._state: bool | None = None
         self._brightness: float | None = None
-        self._locked: bool | None = None
 
         super().__init__(
             device,
@@ -60,21 +57,6 @@ class MovementDetector(Base):
         """Get the brightness level of the sensor."""
         return self._brightness
 
-    @property
-    def locked(self) -> bool | None:
-        """Get the locked state of the sensor."""
-        return self._locked
-
-    async def lock(self):
-        """Lock the sensor."""
-        await self._set_locking_datapoint("1")
-        self._locked = True
-
-    async def unlock(self):
-        """Unlock the sensor."""
-        await self._set_locking_datapoint("0")
-        self._locked = False
-
     def _refresh_state_from_datapoint(self, datapoint: dict[str, Any]) -> str:
         """
         Refresh the state of the channel from a given output.
@@ -88,18 +70,78 @@ class MovementDetector(Base):
             case Pairing.AL_BRIGHTNESS_LEVEL.value:
                 self._brightness = float(datapoint.get("value"))
                 return "brightness"
-            case Pairing.AL_INFO_LOCKED_SENSOR.value:
-                self._locked = datapoint.get("value") == "1"
-                return "locked"
             case _:
                 return None
 
-    async def _set_locking_datapoint(self, value: str):
-        """Set the locking datapoint on the api."""
-        _locking_input_id, _ = self.get_input_by_pairing(pairing=Pairing.AL_LOCK_SENSOR)
+
+class BlockableMovementDetector(MovementDetector):
+    """Free@Home BlockableMovementDetector Class."""
+
+    _state_refresh_pairings: list[Pairing] = [
+        Pairing.AL_TIMED_MOVEMENT,
+        Pairing.AL_BRIGHTNESS_LEVEL,
+        Pairing.AL_INFO_LOCKED_SENSOR,
+    ]
+    _callback_attributes: list[str] = [
+        "state",
+        "brightness",
+        "blocked",
+    ]
+
+    def __init__(
+        self,
+        device: "Device",
+        channel_id: str,
+        channel_name: str,
+        inputs: dict[str, dict[str, Any]],
+        outputs: dict[str, dict[str, Any]],
+        parameters: dict[str, dict[str, Any]],
+        floor_name: str | None = None,
+        room_name: str | None = None,
+    ) -> None:
+        """Initialize the Free@Home BlockableMovementDetector class."""
+        self._blocked: bool | None = None
+
+        super().__init__(
+            device,
+            channel_id,
+            channel_name,
+            inputs,
+            outputs,
+            parameters,
+            floor_name,
+            room_name,
+        )
+
+    @property
+    def blocked(self) -> bool | None:
+        """Get the blocked state of the sensor."""
+        return self._blocked
+
+    async def turn_on_blocked(self):
+        """Block the sensor."""
+        await self._set_blocking_datapoint("1")
+        self._blocked = True
+
+    async def turn_off_blocked(self):
+        """Unblock the sensor."""
+        await self._set_blocking_datapoint("0")
+        self._blocked = False
+
+    def _refresh_state_from_datapoint(self, datapoint: dict[str, Any]) -> str:
+        if datapoint.get("pairingID") == Pairing.AL_INFO_LOCKED_SENSOR.value:
+            self._blocked = datapoint.get("value") == "1"
+            return "blocked"
+        return super()._refresh_state_from_datapoint(datapoint)
+
+    async def _set_blocking_datapoint(self, value: str):
+        """Set the blocking datapoint on the api."""
+        _blocking_input_id, _ = self.get_input_by_pairing(
+            pairing=Pairing.AL_LOCK_SENSOR
+        )
         return await self.device.api.set_datapoint(
             device_serial=self.device_serial,
             channel_id=self.channel_id,
-            datapoint=_locking_input_id,
+            datapoint=_blocking_input_id,
             value=value,
         )

--- a/src/abbfreeathome/const.py
+++ b/src/abbfreeathome/const.py
@@ -88,6 +88,7 @@ FUNCTION_CHANNEL_MAPPING: dict[Function, Base] = {
     Function.FID_FORCE_ON_OFF_SENSOR: ForceOnOffSensor,
     Function.FID_HEATING_ACTUATOR: HeatingActuator,
     Function.FID_MOVEMENT_DETECTOR: MovementDetector,
+    Function.FID_MOVEMENT_DETECTOR_TYPE0: MovementDetector,
     Function.FID_MOVEMENT_DETECTOR_TYPE7: MovementDetector,
     Function.FID_RAIN_SENSOR: RainSensor,
     Function.FID_ROOM_TEMPERATURE_CONTROLLER_MASTER_WITHOUT_FAN: (

--- a/src/abbfreeathome/const.py
+++ b/src/abbfreeathome/const.py
@@ -16,7 +16,7 @@ from .channels.des_door_ringing_sensor import DesDoorRingingSensor
 from .channels.dimming_actuator import ColorTemperatureActuator, DimmingActuator
 from .channels.force_on_off_sensor import ForceOnOffSensor
 from .channels.heating_actuator import HeatingActuator
-from .channels.movement_detector import MovementDetector
+from .channels.movement_detector import BlockableMovementDetector, MovementDetector
 from .channels.rain_sensor import RainSensor
 from .channels.room_temperature_controller import RoomTemperatureController
 from .channels.smoke_detector import SmokeDetector
@@ -91,7 +91,7 @@ FUNCTION_CHANNEL_MAPPING: dict[Function, Base] = {
     Function.FID_FORCE_ON_OFF_SENSOR: ForceOnOffSensor,
     Function.FID_HEATING_ACTUATOR: HeatingActuator,
     Function.FID_MOVEMENT_DETECTOR: MovementDetector,
-    Function.FID_MOVEMENT_DETECTOR_TYPE0: MovementDetector,
+    Function.FID_MOVEMENT_DETECTOR_TYPE0: BlockableMovementDetector,
     Function.FID_MOVEMENT_DETECTOR_TYPE7: MovementDetector,
     Function.FID_RAIN_SENSOR: RainSensor,
     Function.FID_ROOM_TEMPERATURE_CONTROLLER_MASTER_WITHOUT_FAN: (

--- a/tests/test_movement_detector.py
+++ b/tests/test_movement_detector.py
@@ -5,7 +5,10 @@ from unittest.mock import AsyncMock, MagicMock, call
 import pytest
 
 from src.abbfreeathome.api import FreeAtHomeApi
-from src.abbfreeathome.channels.movement_detector import MovementDetector
+from src.abbfreeathome.channels.movement_detector import (
+    BlockableMovementDetector,
+    MovementDetector,
+)
 from src.abbfreeathome.device import Device
 
 
@@ -26,9 +29,23 @@ def get_movement_detector(type: str, mock_api, mock_device):
     if type == "outdoor":
         outputs.pop("odp0002")
 
+    # If it's not blockable it won't have blocking feature
+    if type != "blockable":
+        inputs.pop("idp0004")
+        outputs.pop("odp0005")
+
     mock_device.device_serial = "ABB7F500E17A"
     mock_device.api = mock_api
 
+    if type == "blockable":
+        return BlockableMovementDetector(
+            device=mock_device,
+            channel_id="ch0003",
+            channel_name="Channel Name",
+            inputs=inputs,
+            outputs=outputs,
+            parameters=parameters,
+        )
     return MovementDetector(
         device=mock_device,
         channel_id="ch0003",
@@ -41,91 +58,150 @@ def get_movement_detector(type: str, mock_api, mock_device):
 
 @pytest.fixture
 def mock_api():
-    """Create a mock api function."""
+    """Create a mock api."""
     return AsyncMock(spec=FreeAtHomeApi)
 
 
 @pytest.fixture
-def movement_detector_indoor(mock_api, mock_device):
-    """Set up the switch instance for testing the SwitchActuator channel."""
+def mock_device():
+    """Create a mock device."""
+    return MagicMock(spec=Device)
+
+
+@pytest.fixture
+def indoor_movement_detector(mock_api, mock_device):
+    """Create an instance for testing the indoor MovementDetector."""
     return get_movement_detector("indoor", mock_api, mock_device)
 
 
 @pytest.fixture
-def movement_detector_outdoor(mock_api, mock_device):
-    """Set up the switch instance for testing the SwitchActuator channel."""
+def outdoor_movement_detector(mock_api, mock_device):
+    """Create an instance for testing the outdoor MovementDetector."""
     return get_movement_detector("outdoor", mock_api, mock_device)
 
 
 @pytest.fixture
-def mock_device():
-    """Create a mock device function."""
-    return MagicMock(spec=Device)
+def blockable_movement_detector(mock_api, mock_device):
+    """Create an instance for testing the BlockableMovementDetector."""
+    return get_movement_detector("blockable", mock_api, mock_device)
 
 
 @pytest.mark.asyncio
-async def test_initial_state_indoor(movement_detector_indoor):
-    """Test the intial state."""
-    assert movement_detector_indoor.state is False
-    assert movement_detector_indoor.brightness == 1.6
-    assert movement_detector_indoor.locked is False
+async def test_initial_state_indoor(indoor_movement_detector):
+    """Test the intial state (indoor)."""
+    assert indoor_movement_detector.state is False
+    assert indoor_movement_detector.brightness == 1.6
 
 
 @pytest.mark.asyncio
-async def test_initial_state_outdoor(movement_detector_outdoor):
-    """Test the intial state."""
-    assert movement_detector_outdoor.state is False
-    assert movement_detector_outdoor.brightness is None
-    assert movement_detector_outdoor.locked is False
+async def test_initial_state_outdoor(outdoor_movement_detector):
+    """Test the intial state (outdoor)."""
+    assert outdoor_movement_detector.state is False
+    assert outdoor_movement_detector.brightness is None
 
 
 @pytest.mark.asyncio
-async def test_refresh_state(movement_detector_indoor):
+async def test_initial_state_blockable(blockable_movement_detector):
+    """Test the intial state (blockable)."""
+    assert blockable_movement_detector.state is False
+    assert blockable_movement_detector.brightness == 1.6
+    assert blockable_movement_detector.blocked is False
+
+
+@pytest.mark.asyncio
+async def test_refresh_state(indoor_movement_detector):
     """Test refreshing the state."""
-    movement_detector_indoor.device.api.get_datapoint.side_effect = [
+    indoor_movement_detector.device.api.get_datapoint.side_effect = [
+        ["1"],
+        ["42.1"],
+        # ["1"],
+    ]
+    await indoor_movement_detector.refresh_state()
+    assert indoor_movement_detector.state is True
+    assert indoor_movement_detector.brightness == 42.1
+    _expected_calls = [
+        call(device_serial="ABB7F500E17A", channel_id="ch0003", datapoint="odp0000"),
+        call(device_serial="ABB7F500E17A", channel_id="ch0003", datapoint="odp0002"),
+    ]
+    indoor_movement_detector.device.api.get_datapoint.assert_has_calls(_expected_calls)
+
+
+@pytest.mark.asyncio
+async def test_refresh_state_blockable(blockable_movement_detector):
+    """Test refreshing the state (blockable)."""
+    blockable_movement_detector.device.api.get_datapoint.side_effect = [
         ["1"],
         ["42.1"],
         ["1"],
     ]
-    await movement_detector_indoor.refresh_state()
-    assert movement_detector_indoor.state is True
-    assert movement_detector_indoor.brightness == 42.1
-    assert movement_detector_indoor.locked is True
+    await blockable_movement_detector.refresh_state()
+    assert blockable_movement_detector.state is True
+    assert blockable_movement_detector.brightness == 42.1
+    assert blockable_movement_detector.blocked is True
     _expected_calls = [
         call(device_serial="ABB7F500E17A", channel_id="ch0003", datapoint="odp0000"),
         call(device_serial="ABB7F500E17A", channel_id="ch0003", datapoint="odp0002"),
         call(device_serial="ABB7F500E17A", channel_id="ch0003", datapoint="odp0005"),
     ]
-    movement_detector_indoor.device.api.get_datapoint.assert_has_calls(_expected_calls)
+    blockable_movement_detector.device.api.get_datapoint.assert_has_calls(
+        _expected_calls
+    )
 
 
-def test_refresh_state_from_datapoint(movement_detector_indoor):
+def test_refresh_state_from_datapoint(indoor_movement_detector):
     """Test the _refresh_state_from_datapoint function."""
     # Check output that affects the state.
-    movement_detector_indoor._refresh_state_from_datapoint(
+    indoor_movement_detector._refresh_state_from_datapoint(
         datapoint={"pairingID": 6, "value": "1"},
     )
-    assert movement_detector_indoor.state is True
+    assert indoor_movement_detector.state is True
 
     # Check output that affects the state.
-    movement_detector_indoor._refresh_state_from_datapoint(
+    indoor_movement_detector._refresh_state_from_datapoint(
         datapoint={"pairingID": 1027, "value": "52.3"},
     )
-    assert movement_detector_indoor.brightness == 52.3
+    assert indoor_movement_detector.brightness == 52.3
 
     # Check output that does NOT affect the state.
-    movement_detector_indoor._refresh_state_from_datapoint(
+    indoor_movement_detector._refresh_state_from_datapoint(
         datapoint={"pairingID": 6, "value": "0"},
     )
-    assert movement_detector_indoor.brightness == 52.3
+    assert indoor_movement_detector.brightness == 52.3
+
+
+def test_refresh_state_from_datapoint_blockable(blockable_movement_detector):
+    """Test the _refresh_state_from_datapoint function (blockable)."""
+    # Check output that affects the state.
+    blockable_movement_detector._refresh_state_from_datapoint(
+        datapoint={"pairingID": 6, "value": "1"},
+    )
+    assert blockable_movement_detector.state is True
+
+    # Check output that affects the state.
+    blockable_movement_detector._refresh_state_from_datapoint(
+        datapoint={"pairingID": 1027, "value": "52.3"},
+    )
+    assert blockable_movement_detector.brightness == 52.3
+
+    # Check output that affects the state.
+    blockable_movement_detector._refresh_state_from_datapoint(
+        datapoint={"pairingID": 360, "value": "1"},
+    )
+    assert blockable_movement_detector.blocked is True
+
+    # Check output that does NOT affect the state.
+    blockable_movement_detector._refresh_state_from_datapoint(
+        datapoint={"pairingID": 6, "value": "0"},
+    )
+    assert blockable_movement_detector.brightness == 52.3
 
 
 @pytest.mark.asyncio
-async def test_lock(movement_detector_indoor):
-    """Test for locking the sensor."""
-    await movement_detector_indoor.lock()
-    assert movement_detector_indoor.locked is True
-    movement_detector_indoor.device.api.set_datapoint.assert_called_with(
+async def test_block(blockable_movement_detector):
+    """Test for blocking the sensor."""
+    await blockable_movement_detector.turn_on_blocked()
+    assert blockable_movement_detector.blocked is True
+    blockable_movement_detector.device.api.set_datapoint.assert_called_with(
         device_serial="ABB7F500E17A",
         channel_id="ch0003",
         datapoint="idp0004",
@@ -134,11 +210,11 @@ async def test_lock(movement_detector_indoor):
 
 
 @pytest.mark.asyncio
-async def test_unlock(movement_detector_indoor):
-    """Test for unlocking the sensor."""
-    await movement_detector_indoor.unlock()
-    assert movement_detector_indoor.locked is False
-    movement_detector_indoor.device.api.set_datapoint.assert_called_with(
+async def test_unblock(blockable_movement_detector):
+    """Test for unblocking the sensor."""
+    await blockable_movement_detector.turn_off_blocked()
+    assert blockable_movement_detector.blocked is False
+    blockable_movement_detector.device.api.set_datapoint.assert_called_with(
         device_serial="ABB7F500E17A",
         channel_id="ch0003",
         datapoint="idp0004",

--- a/tests/test_movement_detector.py
+++ b/tests/test_movement_detector.py
@@ -114,7 +114,6 @@ async def test_refresh_state(indoor_movement_detector):
     indoor_movement_detector.device.api.get_datapoint.side_effect = [
         ["1"],
         ["42.1"],
-        # ["1"],
     ]
     await indoor_movement_detector.refresh_state()
     assert indoor_movement_detector.state is True
@@ -155,17 +154,20 @@ def test_refresh_state_from_datapoint(indoor_movement_detector):
         datapoint={"pairingID": 6, "value": "1"},
     )
     assert indoor_movement_detector.state is True
+    assert indoor_movement_detector.brightness == 1.6
 
     # Check output that affects the state.
     indoor_movement_detector._refresh_state_from_datapoint(
         datapoint={"pairingID": 1027, "value": "52.3"},
     )
+    assert indoor_movement_detector.state is True
     assert indoor_movement_detector.brightness == 52.3
 
     # Check output that does NOT affect the state.
     indoor_movement_detector._refresh_state_from_datapoint(
-        datapoint={"pairingID": 6, "value": "0"},
+        datapoint={"pairingID": 12, "value": "0"},
     )
+    assert indoor_movement_detector.state is True
     assert indoor_movement_detector.brightness == 52.3
 
 
@@ -176,24 +178,32 @@ def test_refresh_state_from_datapoint_blockable(blockable_movement_detector):
         datapoint={"pairingID": 6, "value": "1"},
     )
     assert blockable_movement_detector.state is True
+    assert blockable_movement_detector.brightness == 1.6
+    assert blockable_movement_detector.blocked is False
 
     # Check output that affects the state.
     blockable_movement_detector._refresh_state_from_datapoint(
         datapoint={"pairingID": 1027, "value": "52.3"},
     )
+    assert blockable_movement_detector.state is True
     assert blockable_movement_detector.brightness == 52.3
+    assert blockable_movement_detector.blocked is False
 
     # Check output that affects the state.
     blockable_movement_detector._refresh_state_from_datapoint(
         datapoint={"pairingID": 360, "value": "1"},
     )
+    assert blockable_movement_detector.state is True
+    assert blockable_movement_detector.brightness == 52.3
     assert blockable_movement_detector.blocked is True
 
     # Check output that does NOT affect the state.
     blockable_movement_detector._refresh_state_from_datapoint(
-        datapoint={"pairingID": 6, "value": "0"},
+        datapoint={"pairingID": 12, "value": "0"},
     )
+    assert blockable_movement_detector.state is True
     assert blockable_movement_detector.brightness == 52.3
+    assert blockable_movement_detector.blocked is True
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
I recently purchased a movement detector "Busch-Jaeger 62762 UJ-84-WL" that was not fully recognized, so I added the used FID_MOVEMENT_DETECTOR_TYPE0 to the constants.

This movement detector also supports being (un)locked ("Bewegungserkennung sperren" in the German app). Therefore, the property "locked" and the methods lock() and unlock() have been added.

In the next step, I will try to integrate these changes into "local-abbfreeathome-hass" and create another pull request.