### PR TITLE
Put SSL context behind an async function, inject into event loop

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ packages = ["src/abbfreeathome"]
 
 [project]
 name = "local-abbfreeathome"
-version = "3.1.2b1"
+version = "3.1.2"
 authors = [
   { name="Adam Kingsley", email="adam@kingsley.io" },
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ packages = ["src/abbfreeathome"]
 
 [project]
 name = "local-abbfreeathome"
-version = "3.1.1"
+version = "3.1.2b1"
 authors = [
   { name="Adam Kingsley", email="adam@kingsley.io" },
 ]

--- a/src/abbfreeathome/api.py
+++ b/src/abbfreeathome/api.py
@@ -76,7 +76,7 @@ class SSLContextMixin:
             return False
         if self._ssl_cert_ca_file:
             # Run SSL context creation in executor to avoid blocking the event loop
-            loop = asyncio.get_event_loop()
+            loop = asyncio.get_running_loop()
             return await loop.run_in_executor(
                 None, self._create_ssl_context_sync, self._ssl_cert_ca_file
             )

--- a/src/abbfreeathome/api.py
+++ b/src/abbfreeathome/api.py
@@ -66,12 +66,20 @@ _LOGGER = logging.getLogger(__name__)
 class SSLContextMixin:
     """Mixin class to provide SSL context functionality."""
 
-    def _get_ssl_context(self) -> ssl.SSLContext | bool:
+    def _create_ssl_context_sync(self, cafile: str) -> ssl.SSLContext:
+        """Create SSL context synchronously (for use in executor)."""
+        return ssl.create_default_context(cafile=cafile)
+
+    async def _get_ssl_context(self) -> ssl.SSLContext | bool:
         """Get the SSL context for requests."""
         if not self._verify_ssl:
             return False
         if self._ssl_cert_ca_file:
-            return ssl.create_default_context(cafile=self._ssl_cert_ca_file)
+            # Run SSL context creation in executor to avoid blocking the event loop
+            loop = asyncio.get_event_loop()
+            return await loop.run_in_executor(
+                None, self._create_ssl_context_sync, self._ssl_cert_ca_file
+            )
         return True
 
 
@@ -110,10 +118,11 @@ class FreeAtHomeSettings(SSLContextMixin):
 
     async def load(self):
         """Load settings into the class object."""
+        ssl_context = await self._get_ssl_context()
         try:
             async with (
                 self._get_client_session().get(
-                    f"{self._host}/settings.json", ssl=self._get_ssl_context()
+                    f"{self._host}/settings.json", ssl=ssl_context
                 ) as resp,
             ):
                 _response_status = resp.status
@@ -315,6 +324,7 @@ class FreeAtHomeApi(SSLContextMixin):
             path = f"/{path}"
         _full_path = f"/fhapi/{API_VERSION}{path}"
 
+        ssl_context = await self._get_ssl_context()
         try:
             async with (
                 self._get_client_session().request(
@@ -323,7 +333,7 @@ class FreeAtHomeApi(SSLContextMixin):
                     data=data,
                     auth=self._auth,
                     raise_for_status=True,
-                    ssl=self._get_ssl_context(),
+                    ssl=ssl_context,
                 ) as resp,
             ):
                 _response_status = resp.status
@@ -370,12 +380,13 @@ class FreeAtHomeApi(SSLContextMixin):
         _full_path = f"{_parsed_host.hostname}/fhapi/{API_VERSION}/api/ws"
         _url = f"{_protocol}://{_full_path}"
 
+        ssl_context = await self._get_ssl_context()
         _LOGGER.info("Websocket attempting to connect %s", _url)
         self._ws_response = await self._get_client_session().ws_connect(
             url=_url,
             heartbeat=self._ws_heartbeat,
             auth=self._auth,
-            ssl=self._get_ssl_context(),
+            ssl=ssl_context,
         )
         _LOGGER.info("Websocket connected %s", _url)
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -930,13 +930,16 @@ async def test_ws_receive_unknown_message_type(api):
     assert result is None
 
 
-def test_settings_get_ssl_context_no_verify():
+@pytest.mark.asyncio
+async def test_settings_get_ssl_context_no_verify():
     """Test _get_ssl_context returns False when verify_ssl is False."""
     settings = FreeAtHomeSettings(host="http://192.168.1.1", verify_ssl=False)
-    assert settings._get_ssl_context() is False
+    result = await settings._get_ssl_context()
+    assert result is False
 
 
-def test_settings_get_ssl_context_with_cert_path():
+@pytest.mark.asyncio
+async def test_settings_get_ssl_context_with_cert_path():
     """Test _get_ssl_context returns SSLContext when ssl_cert_ca_file is provided."""
     settings = FreeAtHomeSettings(
         host="http://192.168.1.1", verify_ssl=True, ssl_cert_ca_file="dummy_path"
@@ -944,20 +947,22 @@ def test_settings_get_ssl_context_with_cert_path():
     with patch("ssl.create_default_context") as mock_create_context:
         mock_context = Mock()
         mock_create_context.return_value = mock_context
-        context = settings._get_ssl_context()
+        context = await settings._get_ssl_context()
         assert context is mock_context
         mock_create_context.assert_called_once_with(cafile="dummy_path")
 
 
-def test_api_get_ssl_context_no_verify():
+@pytest.mark.asyncio
+async def test_api_get_ssl_context_no_verify():
     """Test _get_ssl_context returns False when verify_ssl is False."""
     api = FreeAtHomeApi(
         host="http://192.168.1.1", username="user", password="pass", verify_ssl=False
     )
-    assert api._get_ssl_context() is False
+    assert await api._get_ssl_context() is False
 
 
-def test_api_get_ssl_context_with_cert_path():
+@pytest.mark.asyncio
+async def test_api_get_ssl_context_with_cert_path():
     """Test _get_ssl_context returns SSLContext when ssl_cert_ca_file is provided."""
     api = FreeAtHomeApi(
         host="http://192.168.1.1",
@@ -969,6 +974,6 @@ def test_api_get_ssl_context_with_cert_path():
     with patch("ssl.create_default_context") as mock_create_context:
         mock_context = Mock()
         mock_create_context.return_value = mock_context
-        context = api._get_ssl_context()
+        context = await api._get_ssl_context()
         assert context is mock_context
         mock_create_context.assert_called_once_with(cafile="dummy_path")


### PR DESCRIPTION
When testing the SSL integration in Home Assistant, I was getting the below warning.

This PR places the SSL context fetching behind an async function, and injects the call into the event loop. This seems to be somewhat common in other projects, see https://github.com/alandtse/alexa_media_player/issues/2504 as an example.

I cut a beta release (https://github.com/kingsleyadam/local-abbfreeathome/releases/tag/3.1.2b1) and verified I'm no longer receiving this warning.

```
2025-09-01 15:49:59.204 WARNING (MainThread) [homeassistant.util.loop] Detected blocking call to load_verify_locations with args (<ssl.SSLContext object at 0xffff1c9c9d00>, '/workspaces/home-assistant-core/config/sysap.crt', None, None) in /home/vscode/.local/share/uv/python/cpython-3.13.5-linux-aarch64-gnu/lib/python3.13/ssl.py, line 717: context.load_verify_locations(cafile, capath, cadata) inside the event loop; This is causing stability issues. Please create a bug report at https://github.com/home-assistant/core/issues?q=is%3Aopen+is%3Aissue
For developers, please see https://developers.home-assistant.io/docs/asyncio_blocking_operations/#load_verify_locations
Traceback (most recent call last):
  File "/home/vscode/.local/share/uv/python/cpython-3.13.5-linux-aarch64-gnu/lib/python3.13/runpy.py", line 198, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/home/vscode/.local/share/uv/python/cpython-3.13.5-linux-aarch64-gnu/lib/python3.13/runpy.py", line 88, in _run_code
    exec(code, run_globals)
  File "/home/vscode/.vscode-server/extensions/ms-python.debugpy-2025.10.0-linux-arm64/bundled/libs/debugpy/adapter/../../debugpy/launcher/../../debugpy/__main__.py", line 71, in <module>
    cli.main()
  File "/home/vscode/.vscode-server/extensions/ms-python.debugpy-2025.10.0-linux-arm64/bundled/libs/debugpy/adapter/../../debugpy/launcher/../../debugpy/../debugpy/server/cli.py", line 501, in main
    run()
  File "/home/vscode/.vscode-server/extensions/ms-python.debugpy-2025.10.0-linux-arm64/bundled/libs/debugpy/adapter/../../debugpy/launcher/../../debugpy/../debugpy/server/cli.py", line 384, in run_module
    run_module_as_main(options.target, alter_argv=True)
  File "/home/vscode/.vscode-server/extensions/ms-python.debugpy-2025.10.0-linux-arm64/bundled/libs/debugpy/_vendored/pydevd/_pydevd_bundle/pydevd_runpy.py", line 228, in _run_module_as_main
    return _run_code(code, main_globals, None, "__main__", mod_spec)
  File "/home/vscode/.vscode-server/extensions/ms-python.debugpy-2025.10.0-linux-arm64/bundled/libs/debugpy/_vendored/pydevd/_pydevd_bundle/pydevd_runpy.py", line 118, in _run_code
    exec(code, run_globals)
  File "/workspaces/home-assistant-core/homeassistant/__main__.py", line 223, in <module>
    sys.exit(main())
  File "/workspaces/home-assistant-core/homeassistant/__main__.py", line 209, in main
    exit_code = runner.run(runtime_conf)
  File "/workspaces/home-assistant-core/homeassistant/runner.py", line 156, in run
    return loop.run_until_complete(setup_and_run_hass(runtime_config))
  File "/home/vscode/.local/share/uv/python/cpython-3.13.5-linux-aarch64-gnu/lib/python3.13/asyncio/base_events.py", line 712, in run_until_complete
    self.run_forever()
  File "/home/vscode/.local/share/uv/python/cpython-3.13.5-linux-aarch64-gnu/lib/python3.13/asyncio/base_events.py", line 683, in run_forever
    self._run_once()
  File "/home/vscode/.local/share/uv/python/cpython-3.13.5-linux-aarch64-gnu/lib/python3.13/asyncio/base_events.py", line 2034, in _run_once
    handle._run()
  File "/home/vscode/.local/share/uv/python/cpython-3.13.5-linux-aarch64-gnu/lib/python3.13/asyncio/events.py", line 89, in _run
    self._context.run(self._callback, *self._args)
  File "/home/vscode/.local/ha-venv/lib/python3.13/site-packages/abbfreeathome/freeathome.py", line 125, in ws_listen
    await self.api.ws_listen(callback=self.update)
  File "/home/vscode/.local/ha-venv/lib/python3.13/site-packages/abbfreeathome/api.py", line 394, in ws_listen
    await self.ws_receive(callback, retry_interval)
  File "/home/vscode/.local/ha-venv/lib/python3.13/site-packages/abbfreeathome/api.py", line 402, in ws_receive
    await self.ws_connect()
  File "/home/vscode/.local/ha-venv/lib/python3.13/site-packages/abbfreeathome/api.py", line 378, in ws_connect
    ssl=self._get_ssl_context(),
  File "/home/vscode/.local/ha-venv/lib/python3.13/site-packages/abbfreeathome/api.py", line 74, in _get_ssl_context
    return ssl.create_default_context(cafile=self._ssl_cert_ca_file)
  File "/home/vscode/.local/share/uv/python/cpython-3.13.5-linux-aarch64-gnu/lib/python3.13/ssl.py", line 717, in create_default_context
    context.load_verify_locations(cafile, capath, cadata)
```