### PR TITLE
Add monkey patch to aioresponses to address issue with aiohttp

### DIFF
--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -1,0 +1,14 @@
+{
+  "features": {
+    "ghcr.io/devcontainers-extra/features/pre-commit:2": {
+      "version": "2.0.18",
+      "resolved": "ghcr.io/devcontainers-extra/features/pre-commit@sha256:6e0bb2ce80caca1d94f44dab5d0653d88a1c00984e590adb7c6bce012d0ade6e",
+      "integrity": "sha256:6e0bb2ce80caca1d94f44dab5d0653d88a1c00984e590adb7c6bce012d0ade6e"
+    },
+    "ghcr.io/va-h/devcontainers-features/uv:latest": {
+      "version": "1.1.4",
+      "resolved": "ghcr.io/va-h/devcontainers-features/uv@sha256:a15737142539d150ef4d358e2d6a7424a0a2f3dc43b29a3aa1b50162a8b11bc1",
+      "integrity": "sha256:a15737142539d150ef4d358e2d6a7424a0a2f3dc43b29a3aa1b50162a8b11bc1"
+    }
+  }
+}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,29 @@
 """Shared test fixtures for the ABB-Free@Home test suite."""
 
+from unittest.mock import Mock
+
+import aiohttp.client_reqrep
 import pytest
 
 from src.abbfreeathome.floorplan import Floorplan
+
+original_init = aiohttp.client_reqrep.ClientResponse.__init__
+
+
+def patched_init(self, method, url, *args, **kwargs):
+    """
+    Add monkeypatch to aioresponses.
+
+    The aiohttp package introduced a new required keyword-only argument "stream_writer"
+    to ClientResponse.__init__ , but aioresponses  currently fails to provide it.
+    See: https://github.com/pnuckowski/aioresponses/issues/289
+    """
+    if "stream_writer" not in kwargs:
+        kwargs["stream_writer"] = Mock()
+    return original_init(self, method, url, *args, **kwargs)
+
+
+aiohttp.client_reqrep.ClientResponse.__init__ = patched_init
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 """Shared test fixtures for the ABB-Free@Home test suite."""
 
+from inspect import signature
 from unittest.mock import Mock
 
 import aiohttp.client_reqrep
@@ -7,23 +8,24 @@ import pytest
 
 from src.abbfreeathome.floorplan import Floorplan
 
-original_init = aiohttp.client_reqrep.ClientResponse.__init__
 
+@pytest.fixture(scope="session", autouse=True)
+def _patch_aiohttp_clientresponse_stream_writer():
+    """Work around aioresponses not passing aiohttp's required stream_writer kwarg."""
+    original_init = aiohttp.client_reqrep.ClientResponse.__init__
 
-def patched_init(self, method, url, *args, **kwargs):
-    """
-    Add monkeypatch to aioresponses.
+    # See: https://github.com/pnuckowski/aioresponses/issues/289
+    if "stream_writer" not in signature(original_init).parameters:
+        yield
+        return
 
-    The aiohttp package introduced a new required keyword-only argument "stream_writer"
-    to ClientResponse.__init__ , but aioresponses  currently fails to provide it.
-    See: https://github.com/pnuckowski/aioresponses/issues/289
-    """
-    if "stream_writer" not in kwargs:
-        kwargs["stream_writer"] = Mock()
-    return original_init(self, method, url, *args, **kwargs)
+    def patched_init(self, method, url, *args, **kwargs):
+        kwargs.setdefault("stream_writer", Mock())
+        return original_init(self, method, url, *args, **kwargs)
 
-
-aiohttp.client_reqrep.ClientResponse.__init__ = patched_init
+    aiohttp.client_reqrep.ClientResponse.__init__ = patched_init
+    yield
+    aiohttp.client_reqrep.ClientResponse.__init__ = original_init
 
 
 @pytest.fixture


### PR DESCRIPTION
The tests use aioresponses to mock api responses, there's currently an issue where aiohttp introduced a breaking change, which has broken aioresponses.

For now, until aioresposnes can get updated I'm adding in a monkey patch to intercept the __init__ call and add in the new required keywaord arg.

See: https://github.com/pnuckowski/aioresponses/issues/289