### PR TITLE
Fix aiohttp compatibility with older versions of Home Assistant

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ async def refresh_state(self):
             }
         )
 
+
 @property
 def state(self) -> bool | None:
     """Get the state of the switch."""
@@ -166,6 +167,7 @@ async def _set_switching_datapoint(self, value: str):
         datapoint=_switch_input_id,
         value=value,
     )
+
 
 async def turn_on(self):
     """Turn on the switch."""
@@ -233,7 +235,7 @@ api = FreeAtHomeApi(
     host="https://<IP or HOSTNAME>",
     username="installer",
     password="<password>",
-    ssl_cert_ca_file="/path/to/your/sysap.crt"
+    ssl_cert_ca_file="/path/to/your/sysap.crt",
 )
 ```
 
@@ -341,7 +343,9 @@ async def websocket_test():
         await _free_at_home.load()
 
         # Add our very own callback
-        for _switch in _free_at_home.get_channels_by_class(channel_class=SwitchActuator):
+        for _switch in _free_at_home.get_channels_by_class(
+            channel_class=SwitchActuator
+        ):
             _switch.register_callback(
                 callback_attribute="state", callback=my_very_own_callback
             )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -119,6 +119,7 @@ ignore = [
   "D203", # 1 blank line required before class docstring
   "D212", # Multi-line docstring summary should start at the first line
   "PLR0913", # Too many arguments to function call ({c_args} > {max_args})
+  "PLR0917", # Too many positional arguments ({c_args} > {max_args})
   "PLR2004", # Magic value used in comparison, consider replacing {value} with a constant variable
 
   # May conflict with the formatter, https://docs.astral.sh/ruff/formatter/#conflicting-lint-rules

--- a/src/abbfreeathome/api.py
+++ b/src/abbfreeathome/api.py
@@ -218,14 +218,6 @@ class FreeAtHomeApi(SSLContextMixin):
     _close_client_session: bool = False
     _ws_response: ClientWebSocketResponse = None
 
-    @staticmethod
-    def _encode_basic_auth(login: str, password: str) -> str:
-        """Encode basic authentication across supported aiohttp versions."""
-        if _aiohttp_encode_basic_auth is not None:
-            return _aiohttp_encode_basic_auth(login=login, password=password)
-
-        return BasicAuth(login, password).encode()
-
     def __init__(
         self,
         host: str,
@@ -595,3 +587,11 @@ class FreeAtHomeApi(SSLContextMixin):
             WSMsgType.CLOSING,
         ):
             _LOGGER.warning("Websocket Connection Closed.")
+
+    @staticmethod
+    def _encode_basic_auth(login: str, password: str) -> str:
+        """Encode basic authentication across supported aiohttp versions."""
+        if _aiohttp_encode_basic_auth is not None:
+            return _aiohttp_encode_basic_auth(login=login, password=password)
+
+        return BasicAuth(login, password).encode()

--- a/src/abbfreeathome/api.py
+++ b/src/abbfreeathome/api.py
@@ -10,7 +10,12 @@ import ssl
 from typing import Any
 from urllib.parse import urlparse
 
-from aiohttp import TCPConnector, encode_basic_auth
+try:
+    from aiohttp import TCPConnector, encode_basic_auth as _aiohttp_encode_basic_auth
+except ImportError:  # pragma: no cover - depends on the installed aiohttp version
+    from aiohttp import BasicAuth, TCPConnector
+
+    _aiohttp_encode_basic_auth = None
 from aiohttp.client import ClientSession, ClientWebSocketResponse
 from aiohttp.client_exceptions import (
     ClientConnectionError as AioHttpClientConnectionError,
@@ -213,6 +218,14 @@ class FreeAtHomeApi(SSLContextMixin):
     _close_client_session: bool = False
     _ws_response: ClientWebSocketResponse = None
 
+    @staticmethod
+    def _encode_basic_auth(login: str, password: str) -> str:
+        """Encode basic authentication across supported aiohttp versions."""
+        if _aiohttp_encode_basic_auth is not None:
+            return _aiohttp_encode_basic_auth(login=login, password=password)
+
+        return BasicAuth(login, password).encode()
+
     def __init__(
         self,
         host: str,
@@ -263,7 +276,7 @@ class FreeAtHomeApi(SSLContextMixin):
         self._host = host.rstrip("/")
         self._username = username
         self._headers = {
-            "Authorization": encode_basic_auth(login=username, password=password)
+            "Authorization": self._encode_basic_auth(login=username, password=password)
         }
         self._sysap_uuid = sysap_uuid
         self._client_session = client_session

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -223,28 +223,35 @@ def test_name_property(settings):
     assert settings.name == "SysAP"
 
 
-@pytest.mark.filterwarnings("ignore:BasicAuth is deprecated:DeprecationWarning")
 def test_basic_auth_falls_back_for_older_aiohttp(monkeypatch):
     """Test basic authentication with aiohttp versions older than 3.14."""
+    basic_auth = Mock()
+    basic_auth.return_value.encode.return_value = "Basic encoded"
+
     monkeypatch.setattr(api_module, "_aiohttp_encode_basic_auth", None)
-    monkeypatch.setattr(api_module, "BasicAuth", aiohttp.BasicAuth, raising=False)
+    monkeypatch.setattr(api_module, "BasicAuth", basic_auth, raising=False)
 
     instance = FreeAtHomeApi(
         host="http://192.168.1.1", username="user", password="pass"
     )
 
-    assert instance._headers["Authorization"] == "Basic dXNlcjpwYXNz"
+    basic_auth.assert_called_once_with("user", "pass")
+    assert instance._headers["Authorization"] == "Basic encoded"
 
 
 def test_basic_auth_supports_aiohttp_without_basic_auth(monkeypatch):
     """Test basic authentication with aiohttp versions newer than 3.x."""
-    monkeypatch.delattr(aiohttp, "BasicAuth", raising=False)
+    encode_basic_auth = Mock(return_value="Basic encoded")
+
+    monkeypatch.setattr(api_module, "_aiohttp_encode_basic_auth", encode_basic_auth)
+    monkeypatch.delattr(api_module, "BasicAuth", raising=False)
 
     instance = FreeAtHomeApi(
         host="http://192.168.1.1", username="user", password="pass"
     )
 
-    assert instance._headers["Authorization"] == "Basic dXNlcjpwYXNz"
+    encode_basic_auth.assert_called_once_with(login="user", password="pass")
+    assert instance._headers["Authorization"] == "Basic encoded"
 
 
 @pytest.mark.asyncio

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -10,6 +10,7 @@ import pytest
 import pytest_asyncio
 import voluptuous as vol
 
+from src.abbfreeathome import api as api_module
 from src.abbfreeathome.api import FreeAtHomeApi, FreeAtHomeSettings
 from src.abbfreeathome.exceptions import (
     BadRequestException,
@@ -220,6 +221,30 @@ def test_name_property(settings):
     """Test getting name."""
     settings._settings = {"flags": {"name": "SysAP"}}
     assert settings.name == "SysAP"
+
+
+@pytest.mark.filterwarnings("ignore:BasicAuth is deprecated:DeprecationWarning")
+def test_basic_auth_falls_back_for_older_aiohttp(monkeypatch):
+    """Test basic authentication with aiohttp versions older than 3.14."""
+    monkeypatch.setattr(api_module, "_aiohttp_encode_basic_auth", None)
+    monkeypatch.setattr(api_module, "BasicAuth", aiohttp.BasicAuth, raising=False)
+
+    instance = FreeAtHomeApi(
+        host="http://192.168.1.1", username="user", password="pass"
+    )
+
+    assert instance._headers["Authorization"] == "Basic dXNlcjpwYXNz"
+
+
+def test_basic_auth_supports_aiohttp_without_basic_auth(monkeypatch):
+    """Test basic authentication with aiohttp versions newer than 3.x."""
+    monkeypatch.delattr(aiohttp, "BasicAuth", raising=False)
+
+    instance = FreeAtHomeApi(
+        host="http://192.168.1.1", username="user", password="pass"
+    )
+
+    assert instance._headers["Authorization"] == "Basic dXNlcjpwYXNz"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Older version of Home Assistant run older versions of the aiohttp package. I added a fix for the outgoing BasicAuth class but that then broke the Home Assistant integration (caught via Unit Tests in the HA integration code).

This adds a sort of shim that'll check for the existence of the new function, if it doesn't exist, it'll fall-back to BasicAuth. Depending on the version of aiohttp the new function OR the BasicAuth class will exist (or both as it currently sits) so this code should work on previous and future version of aiohttp.