### PR TITLE
Remove vscodeintellicode from dev container, bump version

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -16,7 +16,6 @@
         "charliermarsh.ruff",
         "ms-python.pylint",
         "ms-python.vscode-pylance",
-        "visualstudioexptteam.vscodeintellicode",
         "ms-python.debugpy",
         "esbenp.prettier-vscode",
         "GitHub.vscode-pull-request-github",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ packages = ["src/abbfreeathome"]
 
 [project]
 name = "local-abbfreeathome"
-version = "3.6.0"
+version = "3.6.1"
 authors = [
   { name="Adam Kingsley", email="adam@kingsley.io" },
 ]


### PR DESCRIPTION
The vscodeintellicode extension is deprecated, removing it from the dev container.