### PR TITLE
Add StaircaseLightSensor channel for FID_STAIRCASE_LIGHT_SENSOR

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ The current channels implemented within the library.
 | WindSensor | `turn_on()`, `turn_off()`, `set_speed()`, `set_force()` | `speed`, `force`, `alarm` |
 | WindowDoorSensor | `turn_on()`, `turn_off()` | `state` |
 
-\*DimmingSensor, StaircaseLightSensor, and SwitchSensor: `turn_on_led()`and `turn_off_led()` refers to the LED of the sensor. It only has an effect when the "LED mode" is set to "Status Indication".
+\*DimmingSensor, StaircaseLightSensor, and SwitchSensor: `turn_on_led()` and `turn_off_led()` refer to the LED of the sensor. It only has an effect when the "LED mode" is set to "Status Indication".
 
 ## FreeAtHome Class Structure and API Interaction
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ The current channels implemented within the library.
 | RainSensor | | `state` |
 | RoomTemperatureController | `turn_on()`, `turn_off()`, `eco_on()`, `eco_off()`, `set_temperature()` | `state`, `current_temperature`, `valve`, `target_temperature`, `state_indication`, `eco_mode` |
 | SmokeDetector | | `state` |
+| StaircaseLightSensor\* | `turn_on_led()`, `turn_off_led()` | `state` |
 | SwitchActuator | `turn_on()`, `turn_off()`, `set_forced_position()` | `state`, `forced_position` |
 | SwitchSensor\* | `turn_on_led()`, `turn_off_led()` | `state` |
 | TemperatureSensor | | `state`, `alarm` |
@@ -59,7 +60,7 @@ The current channels implemented within the library.
 | WindSensor | `turn_on()`, `turn_off()`, `set_speed()`, `set_force()` | `speed`, `force`, `alarm` |
 | WindowDoorSensor | `turn_on()`, `turn_off()` | `state` |
 
-\*DimmingSensor and SwitchSensor: `turn_on_led()`and `turn_off_led()` refers to the LED of the sensor. It only has an effect when the "LED mode" is set to "Status Indication".
+\*DimmingSensor, StaircaseLightSensor, and SwitchSensor: `turn_on_led()`and `turn_off_led()` refers to the LED of the sensor. It only has an effect when the "LED mode" is set to "Status Indication".
 
 ## FreeAtHome Class Structure and API Interaction
 

--- a/src/abbfreeathome/channels/base.py
+++ b/src/abbfreeathome/channels/base.py
@@ -195,7 +195,7 @@ class Base:
         for _datapoint in self._outputs.values():
             self._refresh_state_from_datapoint(_datapoint)
 
-    def _refresh_state_from_datapoint(self, datapoint: dict[str, Any]) -> str:
+    def _refresh_state_from_datapoint(self, datapoint: dict[str, Any]) -> str | None:
         """Refresh the state of the channel from a single datapoint."""
 
     def __repr__(self) -> str:

--- a/src/abbfreeathome/channels/switch_sensor.py
+++ b/src/abbfreeathome/channels/switch_sensor.py
@@ -96,7 +96,7 @@ class SwitchSensor(Base):
         await self._set_led_datapoint("0")
         self._led = False
 
-    def _refresh_state_from_datapoint(self, datapoint: dict[str, Any]) -> str:
+    def _refresh_state_from_datapoint(self, datapoint: dict[str, Any]) -> str | None:
         """
         Refresh the state of the channel from a given output.
 
@@ -221,7 +221,7 @@ class DimmingSensor(SwitchSensor):
         """Get the dimming state."""
         return self._dimming_sensor_state.name
 
-    def _refresh_state_from_datapoint(self, datapoint: dict[str, Any]) -> str:
+    def _refresh_state_from_datapoint(self, datapoint: dict[str, Any]) -> str | None:
         """
         Refresh the state of the channel from a given output.
 
@@ -256,7 +256,7 @@ class StaircaseLightSensor(SwitchSensor):
         Pairing.AL_TIMED_START_STOP,
     ]
 
-    def _refresh_state_from_datapoint(self, datapoint: dict[str, Any]) -> str:
+    def _refresh_state_from_datapoint(self, datapoint: dict[str, Any]) -> str | None:
         """
         Refresh the state of the channel from a given output.
 

--- a/src/abbfreeathome/channels/switch_sensor.py
+++ b/src/abbfreeathome/channels/switch_sensor.py
@@ -240,3 +240,38 @@ class DimmingSensor(SwitchSensor):
             self._state = self._dimming_sensor_state
             return "state"
         return None
+
+
+class StaircaseLightSensor(SwitchSensor):
+    """
+    Free@Home StaircaseLightSensor Class.
+
+    Sensor (control-element) side of the staircase-timer-light function.
+    Despite the name, it is a timed-pulse push-button that emits an
+    ``AL_TIMED_START_STOP`` telegram on every physical press; commonly linked
+    to non-light targets (e.g. a garage-door opener or a gate).
+    """
+
+    _state_refresh_pairings: list[Pairing] = [
+        Pairing.AL_TIMED_START_STOP,
+    ]
+
+    def _refresh_state_from_datapoint(self, datapoint: dict[str, Any]) -> str:
+        """
+        Refresh the state of the channel from a given output.
+
+        This will return the name of the attribute, which was refreshed or None.
+        """
+        _return_value = super()._refresh_state_from_datapoint(datapoint)
+        if _return_value is not None:
+            return _return_value
+
+        if datapoint.get("pairingID") == Pairing.AL_TIMED_START_STOP.value:
+            try:
+                self._switch_sensor_state = SwitchSensorState(datapoint.get("value"))
+            except ValueError:
+                self._switch_sensor_state = SwitchSensorState.unknown
+
+            self._state = self._switch_sensor_state
+            return "state"
+        return None

--- a/src/abbfreeathome/const.py
+++ b/src/abbfreeathome/const.py
@@ -25,7 +25,7 @@ from .channels.switch_actuator import (
     SwitchActuator,
     WelcomeIPMuteActuator,
 )
-from .channels.switch_sensor import DimmingSensor, SwitchSensor
+from .channels.switch_sensor import DimmingSensor, StaircaseLightSensor, SwitchSensor
 from .channels.temperature_sensor import TemperatureSensor
 from .channels.trigger import Trigger
 from .channels.valve_actuator import (
@@ -124,6 +124,28 @@ FUNCTION_CHANNEL_MAPPING: dict[Function, Base] = {
     ),
     Function.FID_SHUTTER_ACTUATOR: ShutterActuator,
     Function.FID_SMOKE_DETECTOR: SmokeDetector,
+    Function.FID_STAIRCASE_LIGHT_SENSOR: StaircaseLightSensor,
+    Function.FID_PANEL_STAIRCASE_LIGHT_SENSOR: StaircaseLightSensor,
+    Function.FID_PB_STAIRCASE_LIGHT_SENSOR: StaircaseLightSensor,
+    Function.FID_PANEL_STAIRCASE_LIGHT_SENSOR_PUSHBUTTON_TYPE2: StaircaseLightSensor,
+    Function.FID_STAIRCASE_LIGHT_SENSOR_ROCKER_TYPE0: StaircaseLightSensor,
+    Function.FID_STAIRCASE_LIGHT_SENSOR_ROCKER_TYPE1: StaircaseLightSensor,
+    Function.FID_STAIRCASE_LIGHT_SENSOR_ROCKER_TYPE2: StaircaseLightSensor,
+    Function.FID_STAIRCASE_LIGHT_SENSOR_ROCKER_TYPE3: StaircaseLightSensor,
+    Function.FID_STAIRCASE_LIGHT_SENSOR_ROCKER_TYPE4: StaircaseLightSensor,
+    Function.FID_STAIRCASE_LIGHT_SENSOR_ROCKER_TYPE5: StaircaseLightSensor,
+    Function.FID_STAIRCASE_LIGHT_SENSOR_ROCKER_TYPE6: StaircaseLightSensor,
+    Function.FID_STAIRCASE_LIGHT_SENSOR_ROCKER_TYPE7: StaircaseLightSensor,
+    Function.FID_STAIRCASE_LIGHT_SENSOR_ROCKER_TYPE8: StaircaseLightSensor,
+    Function.FID_STAIRCASE_LIGHT_SENSOR_PUSHBUTTON_TYPE0: StaircaseLightSensor,
+    Function.FID_STAIRCASE_LIGHT_SENSOR_PUSHBUTTON_TYPE1: StaircaseLightSensor,
+    Function.FID_STAIRCASE_LIGHT_SENSOR_PUSHBUTTON_TYPE2: StaircaseLightSensor,
+    Function.FID_STAIRCASE_LIGHT_SENSOR_PUSHBUTTON_TYPE3: StaircaseLightSensor,
+    Function.FID_STAIRCASE_LIGHT_SENSOR_PUSHBUTTON_TYPE4: StaircaseLightSensor,
+    Function.FID_STAIRCASE_LIGHT_SENSOR_PUSHBUTTON_TYPE5: StaircaseLightSensor,
+    Function.FID_STAIRCASE_LIGHT_SENSOR_PUSHBUTTON_TYPE6: StaircaseLightSensor,
+    Function.FID_STAIRCASE_LIGHT_SENSOR_PUSHBUTTON_TYPE7: StaircaseLightSensor,
+    Function.FID_STAIRCASE_LIGHT_SENSOR_PUSHBUTTON_TYPE8: StaircaseLightSensor,
     Function.FID_SWITCH_ACTUATOR: SwitchActuator,
     Function.FID_E_CONTACT_SWITCH_ACTUATOR_TYPE0: SwitchActuator,
     Function.FID_E_CONTACT_SWITCH_ACTUATOR_TYPE1: SwitchActuator,

--- a/tests/test_switch_sensor.py
+++ b/tests/test_switch_sensor.py
@@ -8,6 +8,7 @@ from src.abbfreeathome.api import FreeAtHomeApi
 from src.abbfreeathome.channels.switch_sensor import (
     DimmingSensor,
     DimmingSensorState,
+    StaircaseLightSensor,
     SwitchSensor,
     SwitchSensorState,
 )
@@ -99,6 +100,33 @@ def dimming_sensor(mock_api, mock_device):
     return DimmingSensor(
         device=mock_device,
         channel_id="ch0000",
+        channel_name="Channel Name",
+        inputs=inputs,
+        outputs=outputs,
+        parameters=parameters,
+    )
+
+
+@pytest.fixture
+def staircase_light_sensor(mock_api, mock_device):
+    """Set up the staircase-light-sensor instance for testing."""
+    inputs = {
+        "idp0000": {"pairingID": 256, "value": "0"},
+    }
+    outputs = {
+        "odp0005": {"pairingID": 2, "value": "0"},
+        "odp0007": {"pairingID": 4, "value": ""},
+    }
+    parameters = {
+        "par0007": "2",
+    }
+
+    mock_device.device_serial = "ABB700D9C0A4"
+
+    mock_device.api = mock_api
+    return StaircaseLightSensor(
+        device=mock_device,
+        channel_id="ch0004",
         channel_name="Channel Name",
         inputs=inputs,
         outputs=outputs,
@@ -253,6 +281,47 @@ def test_update_channel_without_led(switch_sensor_without_led):
 
     switch_sensor_without_led.update_channel("AL_INFO_ON_OFF/idp0000", "0")
     assert switch_sensor_without_led.led is None
+
+
+def test_refresh_state_from_datapoint_staircase_light(staircase_light_sensor):
+    """Test the _refresh_state_from_datapoint function for StaircaseLightSensor."""
+    # Check output that affects the state via AL_TIMED_START_STOP.
+    staircase_light_sensor._refresh_state_from_datapoint(
+        datapoint={"pairingID": 2, "value": "1"},
+    )
+    assert staircase_light_sensor.state == SwitchSensorState.on.name
+    assert staircase_light_sensor.switching_state == SwitchSensorState.on.name
+
+    staircase_light_sensor._refresh_state_from_datapoint(
+        datapoint={"pairingID": 2, "value": "0"},
+    )
+    assert staircase_light_sensor.state == SwitchSensorState.off.name
+    assert staircase_light_sensor.switching_state == SwitchSensorState.off.name
+
+    staircase_light_sensor._refresh_state_from_datapoint(
+        datapoint={"pairingID": 2, "value": "INVALID"},
+    )
+    assert staircase_light_sensor.state == SwitchSensorState.unknown.name
+
+    # Ensure the LED handling from SwitchSensor is still functional.
+    staircase_light_sensor._refresh_state_from_datapoint(
+        datapoint={"pairingID": 256, "value": "1"},
+    )
+    assert staircase_light_sensor.led is True
+
+
+def test_update_channel_staircase_light(staircase_light_sensor):
+    """Test updating the channel state for StaircaseLightSensor."""
+
+    def test_callback():
+        pass
+
+    staircase_light_sensor.register_callback(
+        callback_attribute="led", callback=test_callback
+    )
+
+    staircase_light_sensor.update_channel("AL_INFO_ON_OFF/idp0000", "1")
+    assert staircase_light_sensor.led is True
 
 
 def test_update_device_nonexistent_input(switch_sensor_with_led):


### PR DESCRIPTION
Adds a StaircaseLightSensor channel class (subclass of SwitchSensor) for timed-pulse push-buttons (e.g. garage-door/gate buttons) exposed via FID_STAIRCASE_LIGHT_SENSOR and its panel/rocker/pushbutton variants. These functions previously had no class mapping, so devices using only these channels were missing entirely from Home Assistant.

- Map AL_TIMED_START_STOP telegrams to SwitchSensorState, reusing the SwitchSensor LED handling (turn_on_led/turn_off_led) for parity.
- Register all FID_STAIRCASE_LIGHT_SENSOR* function IDs in const.py.
- Add tests covering state transitions and LED updates.
- Update README channel table.

Closes #248