### PR TITLE
Map Room temperature controller Type1 functions (0xE5/0xE4)

### DIFF
--- a/src/abbfreeathome/const.py
+++ b/src/abbfreeathome/const.py
@@ -119,6 +119,12 @@ FUNCTION_CHANNEL_MAPPING: dict[Function, Base] = {
     Function.FID_ROOM_TEMPERATURE_CONTROLLER_MASTER_WITHOUT_FAN_TYPE1: (
         RoomTemperatureController
     ),
+    Function.FID_ROOM_TEMPERATURE_CONTROLLER_WITHOUT_FAN_TYPE1: (
+        RoomTemperatureController
+    ),
+    Function.FID_ROOM_TEMPERATURE_CONTROLLER_WITH_FAN_TYPE1: (
+        RoomTemperatureController
+    ),
     Function.FID_PANEL_ROOM_TEMPERATURE_CONTROLLER_MASTER_WITHOUT_FAN: (
         RoomTemperatureController
     ),


### PR DESCRIPTION
## Summary

Adds `FUNCTION_CHANNEL_MAPPING` entries so the Type1 room temperature controller functions resolve to the existing `RoomTemperatureController` channel:

- `FID_ROOM_TEMPERATURE_CONTROLLER_WITHOUT_FAN_TYPE1` (`0xE5` / 229)
- `FID_ROOM_TEMPERATURE_CONTROLLER_WITH_FAN_TYPE1` (`0xE4` / 228)

Both enums already existed but were never mapped, so channels using them were silently skipped and no climate entity was created downstream.

## Motivation

Busch-Jaeger "Touch sensor" (deviceId 4350) exposes a room temperature controller channel with functionID `0xE5`. Its datapoints match exactly what `RoomTemperatureController` consumes — outputs 48/50/51/54/56/304 and inputs 66 (on/off request), 58 (eco), 320 (absolute setpoint request) — so the generic channel works unchanged. The with-fan sibling `0xE4` is mapped alongside it (the channel has no fan-specific logic).

`0xC1` (`FID_PANEL_ROOM_TEMPERATURE_CONTROLLER_MASTER_WITHOUT_FAN`) was already mapped and needed no change.

## Testing

- `ruff check` / `ruff format` clean.
- Existing `test_room_temperature_controller.py` and device/mapping suites pass.

No new tests: mappings aren't asserted per-function elsewhere in the repo, and the parsing path is already covered by existing `RoomTemperatureController` tests.

Closes #251
Related: kingsleyadam/local-abbfreeathome-hass#249