### PR TITLE
Fix inverted position/open/close semantics for AwningActuator

### DIFF
--- a/src/abbfreeathome/channels/cover_actuator.py
+++ b/src/abbfreeathome/channels/cover_actuator.py
@@ -87,6 +87,23 @@ class CoverActuator(Base):
         """Get the information, if the position is forced."""
         return self._forced_position.name
 
+    @property
+    def is_closed(self) -> bool | None:
+        """Get whether the cover is fully closed."""
+        if self._position is None:
+            return None
+        return self._position == 100
+
+    @property
+    def is_opening(self) -> bool:
+        """Get whether the cover is currently opening."""
+        return self._state == CoverActuatorState.opening
+
+    @property
+    def is_closing(self) -> bool:
+        """Get whether the cover is currently closing."""
+        return self._state == CoverActuatorState.closing
+
     async def open(self):
         """Open the cover."""
         await self._set_moving_datapoint("0")
@@ -213,7 +230,47 @@ class AtticWindowActuator(CoverActuator):
 
 
 class AwningActuator(CoverActuator):
-    """Free@Home AwningActuator Class."""
+    """
+    Free@Home AwningActuator Class.
+
+    Free@Home reports awning position with the opposite physical convention to
+    blinds: 0 = retracted (closed), 100 = extended (open). This class inverts
+    internally so its public API matches the other cover classes
+    (0 = open, 100 = closed).
+    """
+
+    async def open(self):
+        """Open (extend) the awning -> public position 0."""
+        await self.set_position(0)
+
+    async def close(self):
+        """Close (retract) the awning -> public position 100."""
+        await self.set_position(100)
+
+    async def set_position(self, value: int):
+        """
+        Set the position of the awning.
+
+        Uses the same public convention as the other cover classes
+        (0 = open, 100 = closed) and inverts to the raw Free@Home value.
+        """
+        value = max(0, value)
+        value = min(value, 100)
+
+        await self._set_position_datapoint(str(100 - value))
+        self._position = value
+
+    def _refresh_state_from_datapoint(self, datapoint: dict[str, Any]) -> str:
+        """Refresh the state, inverting the raw awning position/direction."""
+        attribute = super()._refresh_state_from_datapoint(datapoint)
+        if attribute == "position" and self._position is not None:
+            self._position = 100 - self._position
+        elif attribute == "state":
+            if self._state == CoverActuatorState.opening:
+                self._state = CoverActuatorState.closing
+            elif self._state == CoverActuatorState.closing:
+                self._state = CoverActuatorState.opening
+        return attribute
 
 
 class BlindActuator(CoverActuator):

--- a/src/abbfreeathome/channels/cover_actuator.py
+++ b/src/abbfreeathome/channels/cover_actuator.py
@@ -260,7 +260,7 @@ class AwningActuator(CoverActuator):
         await self._set_position_datapoint(str(100 - value))
         self._position = value
 
-    def _refresh_state_from_datapoint(self, datapoint: dict[str, Any]) -> str:
+    def _refresh_state_from_datapoint(self, datapoint: dict[str, Any]) -> str | None:
         """Refresh the state, inverting the raw awning position/direction."""
         attribute = super()._refresh_state_from_datapoint(datapoint)
         if attribute == "position" and self._position is not None:

--- a/tests/test_cover_actuator.py
+++ b/tests/test_cover_actuator.py
@@ -6,6 +6,7 @@ import pytest
 
 from src.abbfreeathome.api import FreeAtHomeApi
 from src.abbfreeathome.channels.cover_actuator import (
+    AwningActuator,
     CoverActuator,
     CoverActuatorForcedPosition,
     CoverActuatorState,
@@ -89,6 +90,42 @@ def shutter_actuator(mock_api, mock_device):
     mock_device.device_serial = "ABB2AC253651"
     mock_device.api = mock_api
     return ShutterActuator(
+        device=mock_device,
+        channel_id="ch0003",
+        channel_name="Channel Name",
+        inputs=inputs,
+        outputs=outputs,
+        parameters=parameters,
+    )
+
+
+@pytest.fixture
+def awning_actuator(mock_api, mock_device):
+    """Set up the awning actuator instance for testing the AwningActuator channel."""
+    inputs = {
+        "idp0000": {"pairingID": 32, "value": "0"},
+        "idp0001": {"pairingID": 33, "value": "1"},
+        "idp0002": {"pairingID": 35, "value": "70"},
+        "idp0003": {"pairingID": 36, "value": "0"},
+        "idp0004": {"pairingID": 40, "value": "0"},
+        "idp0005": {"pairingID": 37, "value": "0"},
+        "idp0006": {"pairingID": 39, "value": "0"},
+        "idp0007": {"pairingID": 38, "value": "0"},
+        "idp0008": {"pairingID": 4, "value": "0"},
+        "idp0009": {"pairingID": 53, "value": "0"},
+    }
+    outputs = {
+        "odp0000": {"pairingID": 288, "value": "0"},
+        "odp0001": {"pairingID": 289, "value": "0"},
+        "odp0002": {"pairingID": 290, "value": "8"},
+        "odp0003": {"pairingID": 273, "value": "0"},
+        "odp0004": {"pairingID": 257, "value": "0"},
+    }
+    parameters = {}
+
+    mock_device.device_serial = "ABB2AC253651"
+    mock_device.api = mock_api
+    return AwningActuator(
         device=mock_device,
         channel_id="ch0003",
         channel_name="Channel Name",
@@ -339,3 +376,159 @@ async def test_refresh_state_from_datapoint(shutter_actuator):
         datapoint={"pairingID": 0, "value": "1"},
     )
     assert shutter_actuator.position == 2
+
+
+@pytest.mark.asyncio
+async def test_is_closed(cover_actuator):
+    """Test the is_closed property reflects the position."""
+    cover_actuator._position = None
+    assert cover_actuator.is_closed is None
+
+    cover_actuator._position = 100
+    assert cover_actuator.is_closed is True
+
+    cover_actuator._position = 0
+    assert cover_actuator.is_closed is False
+
+    cover_actuator._position = 40
+    assert cover_actuator.is_closed is False
+
+
+@pytest.mark.asyncio
+async def test_is_opening_is_closing(cover_actuator):
+    """Test the is_opening and is_closing properties reflect the state."""
+    cover_actuator._state = CoverActuatorState.opening
+    assert cover_actuator.is_opening is True
+    assert cover_actuator.is_closing is False
+
+    cover_actuator._state = CoverActuatorState.closing
+    assert cover_actuator.is_opening is False
+    assert cover_actuator.is_closing is True
+
+    cover_actuator._state = CoverActuatorState.opened
+    assert cover_actuator.is_opening is False
+    assert cover_actuator.is_closing is False
+
+
+@pytest.mark.asyncio
+async def test_awning_state_inverted(awning_actuator):
+    """Test the moving direction is inverted for awnings."""
+    # Raw opening ("2") -> public closing
+    awning_actuator._refresh_state_from_datapoint(
+        datapoint={"pairingID": 288, "value": "2"}
+    )
+    assert awning_actuator.state == CoverActuatorState.closing.name
+    assert awning_actuator.is_closing is True
+    assert awning_actuator.is_opening is False
+
+    # Raw closing ("3") -> public opening
+    awning_actuator._refresh_state_from_datapoint(
+        datapoint={"pairingID": 288, "value": "3"}
+    )
+    assert awning_actuator.state == CoverActuatorState.opening.name
+    assert awning_actuator.is_opening is True
+    assert awning_actuator.is_closing is False
+
+    # Non-directional state is unchanged
+    awning_actuator._refresh_state_from_datapoint(
+        datapoint={"pairingID": 288, "value": "0"}
+    )
+    assert awning_actuator.state == CoverActuatorState.opened.name
+
+
+@pytest.mark.asyncio
+async def test_awning_is_closed(awning_actuator):
+    """Test is_closed uses the inverted public position for awnings."""
+    # Raw 0 (retracted) -> public 100 -> closed
+    awning_actuator._refresh_state_from_datapoint(
+        datapoint={"pairingID": 289, "value": "0"}
+    )
+    assert awning_actuator.position == 100
+    assert awning_actuator.is_closed is True
+
+    # Raw 100 (extended) -> public 0 -> open
+    awning_actuator._refresh_state_from_datapoint(
+        datapoint={"pairingID": 289, "value": "100"}
+    )
+    assert awning_actuator.position == 0
+    assert awning_actuator.is_closed is False
+
+
+@pytest.mark.asyncio
+async def test_awning_open(awning_actuator):
+    """Test opening (extending) the awning: public position 0 -> raw 100."""
+    await awning_actuator.open()
+    awning_actuator.device.api.set_datapoint.assert_called_with(
+        device_serial="ABB2AC253651",
+        channel_id="ch0003",
+        datapoint="idp0002",
+        value="100",
+    )
+    assert awning_actuator.position == 0
+
+
+@pytest.mark.asyncio
+async def test_awning_close(awning_actuator):
+    """Test closing (retracting) the awning: public position 100 -> raw 0."""
+    await awning_actuator.close()
+    awning_actuator.device.api.set_datapoint.assert_called_with(
+        device_serial="ABB2AC253651",
+        channel_id="ch0003",
+        datapoint="idp0002",
+        value="0",
+    )
+    assert awning_actuator.position == 100
+
+
+@pytest.mark.asyncio
+async def test_awning_set_position(awning_actuator):
+    """Test set_position inverts the public value to the raw Free@Home value."""
+    await awning_actuator.set_position(30)
+    awning_actuator.device.api.set_datapoint.assert_called_with(
+        device_serial="ABB2AC253651",
+        channel_id="ch0003",
+        datapoint="idp0002",
+        value="70",
+    )
+    assert awning_actuator.position == 30
+
+    # Boundaries
+    await awning_actuator.set_position(-1)
+    awning_actuator.device.api.set_datapoint.assert_called_with(
+        device_serial="ABB2AC253651",
+        channel_id="ch0003",
+        datapoint="idp0002",
+        value="100",
+    )
+    assert awning_actuator.position == 0
+
+    await awning_actuator.set_position(120)
+    awning_actuator.device.api.set_datapoint.assert_called_with(
+        device_serial="ABB2AC253651",
+        channel_id="ch0003",
+        datapoint="idp0002",
+        value="0",
+    )
+    assert awning_actuator.position == 100
+
+
+@pytest.mark.asyncio
+async def test_awning_refresh_position_inverted(awning_actuator):
+    """Test the raw Free@Home position is inverted to the public value."""
+    # Raw 100 (extended) -> public 0 (open)
+    awning_actuator._refresh_state_from_datapoint(
+        datapoint={"pairingID": 289, "value": "100"}
+    )
+    assert awning_actuator.position == 0
+
+    # Raw 30 -> public 70
+    awning_actuator._refresh_state_from_datapoint(
+        datapoint={"pairingID": 289, "value": "30"}
+    )
+    assert awning_actuator.position == 70
+
+    # A non-position datapoint should not affect the position
+    awning_actuator._refresh_state_from_datapoint(
+        datapoint={"pairingID": 0, "value": "1"}
+    )
+    assert awning_actuator.position == 70


### PR DESCRIPTION
Fixes #254

## Summary

`AwningActuator` previously inherited blind-oriented behavior from `CoverActuator`, but Free@Home reports the **opposite** physical convention for awnings (`0 = retracted/closed`, `100 = extended/open`). This caused position and open/close semantics to be inverted downstream (e.g. in the HA integration), silently no-op'ing `open`/`close` and breaking safety automations.

## Changes

- **`AwningActuator` inverts internally** so its public API matches the other cover classes (`0 = open, 100 = closed`):
  - `open()` → extend, `close()` → retract, routed through `set_position` (uses the absolute-position datapoint, avoiding the `_set_moving_datapoint("1")` no-op).
  - `set_position` inverts the public value to the raw Free@Home value.
  - `_refresh_state_from_datapoint` inverts the incoming raw position **and** the moving-direction state (`opening` ↔ `closing`).
- **New convenience properties on `CoverActuator`**: `is_closed`, `is_opening`, `is_closing`, so consumers can rely on class-appropriate semantics instead of reconstructing them.

## Decision on normalization

Per the open question in #254: `AwningActuator`'s public `position`/`set_position` are **normalized** to the same convention as the other cover classes. This means the HA integration only needs a version bump — no per-class awning branching required.

## Caveat

The awning **state direction** inversion (`opening` ↔ `closing`) assumes SysAP reports awning extension using the blind "opening" enum. The position inversion is provable from the documented `0/100` conventions; the direction inversion is worth confirming on real awning hardware.

## Testing

- Added tests for awning open/close/set_position, inverted position refresh, inverted state refresh, and the new boolean properties.
- All 18 tests in `tests/test_cover_actuator.py` pass; `ruff` clean.